### PR TITLE
Add Groestlcoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
     * Vertcoin
     * Monacoin
     * DigiByte
+    * Groestlcoin
     * And many other 'Bitcoin Like' cryptos
  * Seed/Passphrase recovery via Address DB (Where you don't need to know an address to search for) supporting:
     * Bitcoin
@@ -20,6 +21,7 @@
     * Vertcoin
     * Monacoin
     * DigiByte
+    * Groestlcoin
     * Likely many other 'Bitcoin like' cryptos
  * [Descrambling 12 word seeds](docs/BIP39_descrambling_seedlists.md) (Using Tokenlist feature for BIP39 seeds via seedrecover.py)
  * Wallet File password recovery for a range of wallets

--- a/bitcoinlib/data/networks.json
+++ b/bitcoinlib/data/networks.json
@@ -246,5 +246,71 @@
     "fee_min": 1000,
     "fee_max": 50000,
     "priority": 6
+  },
+  "groestlcoin":
+  {
+    "description": "Groestlcoin",
+    "currency_name": "groestlcoin",
+    "currency_name_plural": "groestlcoins",
+    "currency_symbol": "Ǥ",
+    "currency_code": "GRS",
+    "prefix_address": "24",
+    "prefix_address_p2sh": "05",
+    "prefix_bech32": "grs",
+    "prefix_wif": "80",
+    "prefixes_wif": [
+      ["0488B21E", "xpub", "public",  false, "legacy",      "p2pkh"],
+      ["0488B21E", "xpub", "public",  true,  "legacy",      "p2sh"],
+      ["0488ADE4", "xprv", "private", false, "legacy",      "p2pkh"],
+      ["0488ADE4", "xprv", "private", true,  "legacy",      "p2sh"],
+      ["049D7CB2", "ypub", "public",  false, "p2sh-segwit", "p2sh_p2wpkh"],
+      ["0295B43F", "Ypub", "public",  true,  "p2sh-segwit", "p2sh_p2wsh"],
+      ["049D7878", "yprv", "private", false, "p2sh-segwit", "p2sh_p2wpkh"],
+      ["0295B005", "Yprv", "private", true,  "p2sh-segwit", "p2sh_p2wsh"],
+      ["04B24746", "zpub", "public",  false, "segwit",      "p2wpkh"],
+      ["02AA7ED3", "Zpub", "public",  true,  "segwit",      "p2wsh"],
+      ["04B2430C", "zprv", "private", false, "segwit",      "p2wpkh"],
+      ["02AA7A99", "Zprv", "private", true,  "segwit",      "p2wsh"]
+    ],
+    "bip44_cointype": 17,
+    "denominator": 0.00000001,
+    "dust_amount": 1000,
+    "fee_default": null,
+    "fee_min": 250,
+    "fee_max": 1000000,
+    "priority": 12
+  },
+  "groestlcoin_testnet":
+  {
+    "description": "Groestlcoin Test Network",
+    "currency_name": "test-groestlcoin",
+    "currency_name_plural": "test-groestlcoins",
+    "currency_symbol": "TGRS",
+    "currency_code": "TGRS",
+    "prefix_address": "6F",
+    "prefix_address_p2sh": "C4",
+    "prefix_bech32": "tgrs",
+    "prefix_wif": "EF",
+    "prefixes_wif": [
+      ["043587CF", "tpub", "public",  false, "legacy",      "p2pkh"],
+      ["043587CF", "tpub", "public",  true,  "legacy",      "p2sh"],
+      ["04358394", "tprv", "private", false, "legacy",      "p2pkh"],
+      ["04358394", "tprv", "private", true,  "legacy",      "p2sh"],
+      ["044A5262", "upub", "public",  false, "p2sh-segwit", "p2sh_p2wpkh"],
+      ["024289EF", "Upub", "public",  true,  "p2sh-segwit", "p2sh_p2wsh"],
+      ["044A4E28", "uprv", "private", false, "p2sh-segwit", "p2sh_p2wpkh"],
+      ["024285B5", "Uprv", "private", true,  "p2sh-segwit", "p2sh_p2wsh"],
+      ["045F1CF6", "vpub", "public",  false, "segwit",      "p2wpkh"],
+      ["02575483", "Vpub", "public",  true,  "segwit",      "p2wsh"],
+      ["045F18BC", "vprv", "private", false, "segwit",      "p2wpkh"],
+      ["02575048", "Vprv", "private", true,  "segwit",      "p2wsh"]
+    ],
+    "bip44_cointype": 1,
+    "denominator": 0.00000001,
+    "dust_amount": 1000,
+    "fee_default": 10000,
+    "fee_min": 250,
+    "fee_max": 2000000,
+    "priority": 8
   }
 }

--- a/bitcoinlib/data/providers.examples.json
+++ b/bitcoinlib/data/providers.examples.json
@@ -394,5 +394,104 @@
     "priority": 10,
     "denominator": 100000000,
     "network_overrides": null
+  },
+  "groestlcoind": {
+    "provider": "groestlcoind",
+    "network": "groestlcoin",
+    "client_class": "GroestlcoindClient",
+    "provider_coin_id": "",
+    "url": "",
+    "api_key": "",
+    "priority": 20,
+    "denominator": 100000000,
+    "network_overrides": null
+  },
+  "groestlcoind.testnet": {
+    "provider": "groestlcoind",
+    "network": "groestlcoin_testnet",
+    "client_class": "GroestlcoindClient",
+    "provider_coin_id": "",
+    "url": "",
+    "api_key": "",
+    "priority": 20,
+    "denominator": 100000000,
+    "network_overrides": null
+  },
+  "groestlcoinesplora": {
+    "provider": "groestlcoinesplora",
+    "network": "groestlcoin",
+    "client_class": "GroestlcoinEsploraClient",
+    "provider_coin_id": "",
+    "url": "https://esplora.groestlcoin.org/api/",
+    "api_key": "",
+    "priority": 10,
+    "denominator": 100000000,
+    "network_overrides": null
+  },
+  "groestlcoinesplora.testnet": {
+    "provider": "groestlcoinesplora",
+    "network": "groestlcoin_testnet",
+    "client_class": "GroestlcoinEsploraClient",
+    "provider_coin_id": "",
+    "url": "https://esplora.groestlcoin.org/testnet/api/",
+    "api_key": "",
+    "priority": 10,
+    "denominator": 100000000,
+    "network_overrides": null
+  },
+  "groestlsight": {
+    "provider": "groestlsight",
+    "network": "groestlcoin",
+    "client_class": "GroestlsightClient",
+    "provider_coin_id": "",
+    "url": "https://groestlsight.groestlcoin.org/api/",
+    "api_key": "",
+    "priority": 10,
+    "denominator": 100000000,
+    "network_overrides": null
+  },
+  "groestlsight.testnet": {
+    "provider": "groestlsight",
+    "network": "groestlcoin_testnet",
+    "client_class": "GroestlsightClient",
+    "provider_coin_id": "",
+    "url": "https://groestlsight-test.groestlcoin.org/api/",
+    "api_key": "",
+    "priority": 10,
+    "denominator": 100000000,
+    "network_overrides": null
+  },
+  "cryptoid.groestlcoin": {
+    "provider": "cryptoid",
+    "network": "groestlcoin",
+    "client_class": "CryptoID",
+    "provider_coin_id": "grs",
+    "url": "https://chainz.cryptoid.info/",
+    "api_key": "",
+    "priority": 10,
+    "denominator": 100000000,
+    "network_overrides": null
+  },
+  "cryptoid.groestlcoin.testnet": {
+    "provider": "cryptoid",
+    "network": "groestlcoin_testnet",
+    "client_class": "CryptoID",
+    "provider_coin_id": "grs-test",
+    "url": "https://chainz.cryptoid.info/",
+    "api_key": "",
+    "priority": 10,
+    "denominator": 100000000,
+    "network_overrides": null
+  },
+  "blockchair.groestlcoin": {
+    "provider": "blockchair",
+    "network": "groestlcoin",
+    "client_class": "BlockChairClient",
+    "provider_coin_id": "",
+    "url": "https://api.blockchair.com/groestlcoin/",
+    "api_key": "",
+    "priority": 10,
+    "denominator": 100000000,
+    "network_overrides": null
   }
 }

--- a/bitcoinlib/data/providers.json
+++ b/bitcoinlib/data/providers.json
@@ -306,5 +306,71 @@
     "priority": 10,
     "denominator": 100000000,
     "network_overrides": null
+  },
+  "groestlcoinesplora": {
+    "provider": "groestlcoinesplora",
+    "network": "groestlcoin",
+    "client_class": "GroestlcoinEsploraClient",
+    "provider_coin_id": "",
+    "url": "https://esplora.groestlcoin.org/api/",
+    "api_key": "",
+    "priority": 10,
+    "denominator": 100000000,
+    "network_overrides": null
+  },
+  "groestlcoinesplora.testnet": {
+    "provider": "groestlcoinesplora",
+    "network": "groestlcoin_testnet",
+    "client_class": "GroestlcoinEsploraClient",
+    "provider_coin_id": "",
+    "url": "https://esplora.groestlcoin.org/testnet/api/",
+    "api_key": "",
+    "priority": 10,
+    "denominator": 100000000,
+    "network_overrides": null
+  },
+  "groestlsight": {
+    "provider": "groestlsight",
+    "network": "groestlcoin",
+    "client_class": "GroestlsightClient",
+    "provider_coin_id": "",
+    "url": "https://groestlsight.groestlcoin.org/api/",
+    "api_key": "",
+    "priority": 10,
+    "denominator": 100000000,
+    "network_overrides": null
+  },
+  "groestlsight.testnet": {
+    "provider": "groestlsight",
+    "network": "groestlcoin_testnet",
+    "client_class": "GroestlsightClient",
+    "provider_coin_id": "",
+    "url": "https://groestlsight-test.groestlcoin.org/api/",
+    "api_key": "",
+    "priority": 10,
+    "denominator": 100000000,
+    "network_overrides": null
+  },
+  "cryptoid.groestlcoin": {
+    "provider": "cryptoid",
+    "network": "groestlcoin",
+    "client_class": "CryptoID",
+    "provider_coin_id": "grs",
+    "url": "https://chainz.cryptoid.info/",
+    "api_key": "",
+    "priority": 10,
+    "denominator": 100000000,
+    "network_overrides": null
+  },
+  "cryptoid.groestlcoin.testnet": {
+    "provider": "cryptoid",
+    "network": "groestlcoin_testnet",
+    "client_class": "CryptoID",
+    "provider_coin_id": "grs-test",
+    "url": "https://chainz.cryptoid.info/",
+    "api_key": "",
+    "priority": 10,
+    "denominator": 100000000,
+    "network_overrides": null
   }
 }

--- a/bitcoinlib/encoding.py
+++ b/bitcoinlib/encoding.py
@@ -28,6 +28,7 @@ import binascii
 import unicodedata
 import struct
 from bitcoinlib.main import *
+import groestlcoin_hash
 _logger = logging.getLogger(__name__)
 
 
@@ -474,6 +475,34 @@ def addr_base58_to_pubkeyhash(address, as_hex=False):
     else:
         return pkh[1:]
 
+def grs_addr_base58_to_pubkeyhash(address, as_hex=False):
+    """
+    Convert Base58 encoded address to public key hash (Groestlcoin)
+
+    >>> addr_base58_to_pubkeyhash('142Zp9WZn9Fh4MV8F3H5Dv4Rbg7Ja1sPWZ', as_hex=True)
+    '21342f229392d7c9ed82c932916cee6517fbc9a2'
+
+    :param address: Crypto currency address in base-58 format
+    :type address: str, bytes
+    :param as_hex: Output as hexstring
+    :type as_hex: bool
+
+    :return bytes, str: Public Key Hash
+    """
+
+    try:
+        address = change_base(address, 58, 256, 25)
+    except EncodingError as err:
+        raise EncodingError("Invalid address %s: %s" % (address, err))
+    check = address[-4:]
+    pkh = address[:-4]
+    #x = to_bytes(pkh, 'utf8')
+    checksum = groestlcoin_hash.getHash(pkh, len(pkh))[0:4]
+    assert (check == checksum), "Invalid GRS address, checksum incorrect"
+    if as_hex:
+        return change_base(pkh, 256, 16)[2:]
+    else:
+        return pkh[1:]
 
 def addr_bech32_to_pubkeyhash(bech, prefix=None, include_witver=False, as_hex=False):
     """

--- a/bitcoinlib/services/groestlcoind.py
+++ b/bitcoinlib/services/groestlcoind.py
@@ -1,0 +1,271 @@
+# -*- coding: utf-8 -*-
+#
+#    BitcoinLib - Python Cryptocurrency Library
+#    Client for groestlcoind deamon
+#    © 2017 June - 1200 Web Development <http://1200wd.com/>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from datetime import datetime
+from bitcoinlib.main import *
+from bitcoinlib.services.authproxy import AuthServiceProxy
+from bitcoinlib.services.baseclient import BaseClient, ClientError
+from bitcoinlib.transactions import Transaction
+from bitcoinlib.encoding import to_hexstring
+from bitcoinlib.networks import Network
+
+
+PROVIDERNAME = 'groestlcoind'
+
+_logger = logging.getLogger(__name__)
+
+
+class ConfigError(Exception):
+    def __init__(self, msg=''):
+        self.msg = msg
+        _logger.info(msg)
+
+    def __str__(self):
+        return self.msg
+
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
+
+
+def _read_from_config(configparser, section, value, fallback=None):
+    try:
+        return configparser.get(section, value)
+    except Exception:
+        return fallback
+
+
+class GroestlcoindClient(BaseClient):
+    """
+    Class to interact with groestlcoind, the Groestlcoin deamon
+    """
+
+    @staticmethod
+    def from_config(configfile=None, network='groestlcoin'):
+        """
+        Read settings from groestlcoind config file
+
+        :param configfile: Path to config file. Leave empty to look in default places
+        :type: str
+        :param network: Groestlcoin mainnet or testnet. Default is groestlcoin mainnet
+        :type: str
+
+        :return GroestlcoindClient:
+        """
+        try:
+            config = configparser.ConfigParser(strict=False)
+        except TypeError:
+            config = configparser.ConfigParser()
+        config_fn = 'groestlcoin.conf'
+        if isinstance(network, Network):
+            network = network.name
+        if network == 'testnet':
+            config_fn = 'groestlcoin-testnet.conf'
+
+        cfn = None
+        if not configfile:
+            config_locations = ['~/.bitcoinlib', '~/.groestlcoin', '~/Application Data/Groestlcoin',
+                                '~/Library/Application Support/Groestlcoin']
+            for location in config_locations:
+                cfn = Path(location, config_fn).expanduser()
+                if cfn.exists():
+                    break
+        else:
+            cfn = Path(BCL_DATA_DIR, 'config', configfile)
+        if not cfn or not cfn.is_file():
+            raise ConfigError("Config file %s not found. Please install groestlcoin client and specify a path to config "
+                              "file if path is not default. Or place a config file in .bitcoinlib/groestlcoin.conf to "
+                              "reference to an external server." % cfn)
+
+        try:
+            config.read(cfn)
+        except Exception:
+            with cfn.open() as f:
+                config_string = '[rpc]\n' + f.read()
+            config.read_string(config_string)
+
+        testnet = _read_from_config(config, 'rpc', 'testnet')
+        if testnet:
+            network = 'testnet'
+        if _read_from_config(config, 'rpc', 'rpcpassword') == 'specify_rpc_password':
+            raise ConfigError("Please update config settings in %s" % cfn)
+        if network == 'testnet':
+            port = 17766
+        else:
+            port = 1441
+        port = _read_from_config(config, 'rpc', 'rpcport', port)
+        server = '127.0.0.1'
+        server = _read_from_config(config, 'rpc', 'rpcconnect', server)
+        server = _read_from_config(config, 'rpc', 'bind', server)
+        server = _read_from_config(config, 'rpc', 'externalip', server)
+
+        url = "http://%s:%s@%s:%s" % (config.get('rpc', 'rpcuser'), config.get('rpc', 'rpcpassword'), server, port)
+        return GroestlcoindClient(network, url)
+
+    def __init__(self, network='groestlcoin', base_url='', denominator=100000000, *args):
+        """
+        Open connection to groestlcoin node
+
+        :param network: Groestlcoin mainnet or testnet. Default is groestlcoin mainnet
+        :type: str
+        :param base_url: Connection URL in format http(s)://user:password@host:port.
+        :type: str
+        :param denominator: Denominator for this currency. Should be always 100000000 (gros) for groestlcoin
+        :type: str
+        """
+        if isinstance(network, Network):
+            network = network.name
+        if not base_url:
+            bdc = self.from_config('', network)
+            base_url = bdc.base_url
+            network = bdc.network
+        if len(base_url.split(':')) != 4:
+            raise ConfigError("Groestlcoind connection URL must be of format 'http(s)://user:password@host:port,"
+                              "current format is %s. Please set url in providers.json file or check groestlcoin config "
+                              "file" % base_url)
+        if 'password' in base_url:
+            raise ConfigError("Invalid password in groestlcoind provider settings. "
+                              "Please replace default password and set url in providers.json or groestlcoin.conf file")
+        _logger.info("Connect to groestlcoind on %s" % base_url)
+        self.proxy = AuthServiceProxy(base_url)
+        super(self.__class__, self).__init__(network, PROVIDERNAME, base_url, denominator, *args)
+
+    # def getbalance
+
+    def getutxos(self, address, after_txid='', max_txs=MAX_TRANSACTIONS):
+        txs = []
+
+        res = self.proxy.getaddressinfo(address)
+        if not (res['ismine'] or res['iswatchonly']):
+            raise ClientError("Address %s not found in groestlcoind wallet, use 'importaddress' to add address to "
+                              "wallet." % address)
+
+        for t in self.proxy.listunspent(0, 99999999, [address]):
+            txs.append({
+                'address': t['address'],
+                'tx_hash': t['txid'],
+                'confirmations': t['confirmations'],
+                'output_n': t['vout'],
+                'input_n': -1,
+                'block_height': None,
+                'fee': None,
+                'size': 0,
+                'value': int(t['amount'] * self.units),
+                'script': t['scriptPubKey'],
+                'date': None,
+            })
+
+        return txs
+
+    def gettransaction(self, txid):
+        tx = self.proxy.getrawtransaction(txid, 1)
+        t = Transaction.import_raw(tx['hex'], network=self.network)
+        t.confirmations = tx['confirmations']
+        if t.confirmations:
+            t.status = 'confirmed'
+            t.verified = True
+        for i in t.inputs:
+            if i.prev_hash == b'\x00' * 32:
+                i.value = t.output_total
+                i.script_type = 'coinbase'
+                continue
+            txi = self.proxy.getrawtransaction(to_hexstring(i.prev_hash), 1)
+            i.value = int(round(float(txi['vout'][i.output_n_int]['value']) / self.network.denominator))
+        for o in t.outputs:
+            o.spent = None
+        t.block_hash = tx['blockhash']
+        t.version = struct.pack('>L', tx['version'])
+        t.date = datetime.fromtimestamp(tx['blocktime'])
+        t.hash = txid
+        t.update_totals()
+        return t
+
+    # def gettransactions
+
+    def getrawtransaction(self, txid):
+        res = self.proxy.getrawtransaction(txid)
+        return res
+
+    def sendrawtransaction(self, rawtx):
+        res = self.proxy.sendrawtransaction(rawtx)
+        return {
+            'txid': res,
+            'response_dict': res
+        }
+
+    def estimatefee(self, blocks):
+        pres = ''
+        try:
+            pres = self.proxy.estimatesmartfee(blocks)
+            res = pres['feerate']
+        except KeyError as e:
+            _logger.info("groestlcoind error: %s, %s" % (e, pres))
+            res = self.proxy.estimatefee(blocks)
+        return int(res * self.units)
+
+    def blockcount(self):
+        return self.proxy.getblockcount()
+
+    def mempool(self, txid=''):
+        txids = self.proxy.getrawmempool()
+        if not txid:
+            return txids
+        elif txid in txids:
+            return [txid]
+        return []
+
+
+if __name__ == '__main__':
+    #
+    # SOME EXAMPLES
+    #
+
+    from pprint import pprint
+
+    # 1. Connect by specifying connection URL
+    # base_url = 'http://RpcUsername:RpcPass@host:1441'
+    # bdc = GroestlcoindClient(base_url=base_url)
+
+    # 2. Or connect using default settings or settings from config file
+    bdc = GroestlcoindClient()
+
+    print("\n=== SERVERINFO ===")
+    pprint(bdc.proxy.getnetworkinfo())
+
+    print("\n=== Best Block ===")
+    blockhash = bdc.proxy.getbestblockhash()
+    bestblock = bdc.proxy.getblock(blockhash)
+    bestblock['tx'] = '...' + str(len(bestblock['tx'])) + ' transactions...'
+    pprint(bestblock)
+
+    print("\n=== Mempool ===")
+    rmp = bdc.proxy.getrawmempool()
+    pprint(rmp[:25])
+    print('... truncated ...')
+    print("Mempool Size %d" % len(rmp))
+
+    print("\n=== Raw Transaction by txid ===")
+    t = bdc.getrawtransaction('7eb5332699644b753cd3f5afba9562e67612ea71ef119af1ac46559adb69ea0d')
+    pprint(t)
+
+    print("\n=== Current network fees ===")
+    t = bdc.estimatefee(5)
+    pprint(t)

--- a/bitcoinlib/services/groestlcoinesplora.py
+++ b/bitcoinlib/services/groestlcoinesplora.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+#
+#    BitcoinLib - Python Cryptocurrency Library
+#    BlockstreamClient client
+#    © 2019 November - 1200 Web Development <http://1200wd.com/>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import logging
+from datetime import datetime
+from bitcoinlib.main import MAX_TRANSACTIONS
+from bitcoinlib.services.baseclient import BaseClient, ClientError
+from bitcoinlib.transactions import Transaction
+from bitcoinlib.encoding import to_hexstring
+
+PROVIDERNAME = 'groestlcoinesplora'
+# Please note: In the Blockstream API, the first couple of Groestlcoin blocks are not correctly indexed,
+# so transactions from these blocks are missing.
+
+_logger = logging.getLogger(__name__)
+
+
+class GroesltcoinEsploraClient(BaseClient):
+
+    def __init__(self, network, base_url, denominator, *args):
+        super(self.__class__, self).__init__(network, PROVIDERNAME, base_url, denominator, *args)
+
+    def compose_request(self, function, data='', parameter='', variables=None, post_data='', method='get'):
+        url_path = function
+        if data:
+            url_path += '/' + data
+        if parameter:
+            url_path += '/' + parameter
+        if variables is None:
+            variables = {}
+        if self.api_key:
+            variables.update({'token': self.api_key})
+        return self.request(url_path, variables, method, post_data=post_data)
+
+    def getbalance(self, addresslist):
+        balance = 0
+        for address in addresslist:
+            res = self.compose_request('address', data=address)
+            balance += (res['chain_stats']['funded_txo_sum'] - res['chain_stats']['spent_txo_sum'])
+        return balance
+
+    def getutxos(self, address, after_txid='', max_txs=MAX_TRANSACTIONS):
+        res = self.compose_request('address', address, 'utxo')
+        blockcount = self.blockcount()
+        utxos = []
+        # # key=lambda k: (k[2], pow(10, 20)-k[0].transaction_id, k[3]), reverse=True
+        res = sorted(res, key=lambda k: 0 if 'block_height' not in k['status'] else k['status']['block_height'])
+        for a in res:
+            confirmations = 0
+            block_height = None
+            if 'block_height' in a['status']:
+                block_height = a['status']['block_height']
+                confirmations = blockcount - block_height
+            utxos.append({
+                'address': address,
+                'tx_hash': a['txid'],
+                'confirmations': confirmations,
+                'output_n': a['vout'],
+                'input_n': 0,
+                'block_height': block_height,
+                'fee': None,
+                'size': 0,
+                'value': a['value'],
+                'script': '',
+                'date': None if 'block_time' not in a['status'] else datetime.fromtimestamp(a['status']['block_time'])
+            })
+            if a['txid'] == after_txid:
+                utxos = []
+        return utxos[:max_txs]
+
+    def _parse_transaction(self, tx, blockcount=None):
+        if not blockcount:
+            blockcount = self.blockcount()
+        confirmations = 0
+        block_height = None
+        if 'block_height' in tx['status']:
+            block_height = tx['status']['block_height']
+            confirmations = blockcount - block_height
+        status = 'unconfirmed'
+        if tx['status']['confirmed']:
+            status = 'confirmed'
+        fee = None if 'fee' not in tx else tx['fee']
+        t = Transaction(locktime=tx['locktime'], version=tx['version'], network=self.network,
+                        fee=fee, size=tx['size'], hash=tx['txid'],
+                        date=None if 'block_time' not in tx['status'] else datetime.fromtimestamp(tx['status']['block_time']),
+                        confirmations=confirmations, block_height=block_height, status=status,
+                        coinbase=tx['vin'][0]['is_coinbase'])
+        index_n = 0
+        for ti in tx['vin']:
+            if tx['vin'][0]['is_coinbase']:
+                t.add_input(prev_hash=ti['txid'], output_n=ti['vout'], index_n=index_n,
+                            unlocking_script=ti['scriptsig'], value=sum([o['value'] for o in tx['vout']]))
+            else:
+                t.add_input(prev_hash=ti['txid'], output_n=ti['vout'],
+                            unlocking_script_unsigned=ti['prevout']['scriptpubkey'], index_n=index_n,
+                            value=ti['prevout']['value'], address=ti['prevout']['scriptpubkey_address'],
+                            unlocking_script=ti['scriptsig'])
+            index_n += 1
+        index_n = 0
+        for to in tx['vout']:
+            address = ''
+            if 'scriptpubkey_address' in to:
+                address = to['scriptpubkey_address']
+            t.add_output(value=to['value'], address=address, lock_script=to['scriptpubkey'],
+                         output_n=index_n, spent=None)
+            index_n += 1
+        if 'segwit' in [i.witness_type for i in t.inputs]:
+            t.witness_type = 'segwit'
+        t.update_totals()
+        return t
+
+    def gettransaction(self, txid):
+        tx = self.compose_request('tx', txid)
+        return self._parse_transaction(tx)
+
+    def gettransactions(self, address, after_txid='', max_txs=MAX_TRANSACTIONS):
+        block_height = self.blockcount()
+        prtxs = []
+        before_txid = ''
+        while True:
+            parameter = 'txs'
+            if before_txid:
+                parameter = 'txs/chain/%s' % before_txid
+            res = self.compose_request('address', address, parameter)
+            prtxs += res
+            if len(res) == 25:
+                before_txid = res[-1:]['txid']
+            else:
+                break
+        txs = []
+        for tx in prtxs[::-1]:
+            t = self._parse_transaction(tx, block_height)
+            if t:
+                txs.append(t)
+            if t.hash == after_txid:
+                txs = []
+            if len(txs) > max_txs:
+                break
+        return txs[:max_txs]
+
+    def getrawtransaction(self, txid):
+        return self.compose_request('tx', txid, 'hex')
+
+    def sendrawtransaction(self, rawtx):
+        res = self.compose_request('tx', post_data=rawtx, method='post')
+        return {
+            'txid': res,
+            'response_dict': res
+        }
+
+    def estimatefee(self, blocks):
+        est = self.compose_request('fee-estimates')
+        closest = (sorted([int(i) - blocks for i in est.keys() if int(i) - blocks >= 0]))
+        if closest:
+            return int(est[str(closest[0] + blocks)] * 1024)
+        else:
+            return int(est[str(sorted([int(i) for i in est.keys()])[-1:][0])] * 1024)
+
+    def blockcount(self):
+        return self.compose_request('blocks', 'tip', 'height')
+
+    def mempool(self, txid):
+        if txid:
+            t = self.gettransaction(txid)
+            if t and not t.confirmations:
+                return [t.hash]
+        else:
+            return self.compose_request('mempool', 'txids')
+        return []

--- a/bitcoinlib/services/groestlsight.py
+++ b/bitcoinlib/services/groestlsight.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+#
+#    BitcoinLib - Python Cryptocurrency Library
+#    Litecore.io Client
+#    © 2018-2019 July - 1200 Web Development <http://1200wd.com/>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from datetime import datetime
+import struct
+from bitcoinlib.main import MAX_TRANSACTIONS
+from bitcoinlib.services.baseclient import BaseClient
+from bitcoinlib.transactions import Transaction
+
+PROVIDERNAME = 'groestlsight'
+REQUEST_LIMIT = 50
+
+
+class GroestlsightClient(BaseClient):
+
+    def __init__(self, network, base_url, denominator, *args):
+        super(self.__class__, self).__init__(network, PROVIDERNAME, base_url, denominator, *args)
+
+    def compose_request(self, category, data, cmd='', variables=None, method='get', offset=0):
+        url_path = category
+        if data:
+            url_path += '/' + data + '/' + cmd
+        if variables is None:
+            variables = {}
+        variables.update({'from': offset, 'to': offset+REQUEST_LIMIT})
+        return self.request(url_path, variables, method=method)
+
+    def _convert_to_transaction(self, tx):
+        if tx['confirmations']:
+            status = 'confirmed'
+        else:
+            status = 'unconfirmed'
+        fees = None if 'fees' not in tx else int(round(float(tx['fees']) * self.units, 0))
+        value_in = 0 if 'valueIn' not in tx else tx['valueIn']
+        isCoinbase = False
+        if 'isCoinBase' in tx and tx['isCoinBase']:
+            value_in = tx['valueOut']
+            isCoinbase = True
+        t = Transaction(locktime=tx['locktime'], version=tx['version'], network=self.network,
+                        fee=fees, size=tx['size'], hash=tx['txid'],
+                        date=datetime.fromtimestamp(tx['blocktime']), confirmations=tx['confirmations'],
+                        block_height=tx['blockheight'], block_hash=tx['blockhash'], status=status,
+                        input_total=int(round(float(value_in) * self.units, 0)), coinbase=isCoinbase,
+                        output_total=int(round(float(tx['valueOut']) * self.units, 0)))
+        for ti in tx['vin']:
+            if isCoinbase:
+                t.add_input(prev_hash=32 * b'\0', output_n=4*b'\xff', unlocking_script=ti['coinbase'], index_n=ti['n'],
+                            script_type='coinbase', sequence=ti['sequence'])
+            else:
+                value = int(round(float(ti['value']) * self.units, 0))
+                t.add_input(prev_hash=ti['txid'], output_n=ti['vout'], unlocking_script=ti['scriptSig']['hex'],
+                            index_n=ti['n'], value=value, sequence=ti['sequence'],
+                            double_spend=False if ti['doubleSpentTxID'] is None else ti['doubleSpentTxID'])
+        for to in tx['vout']:
+            value = int(round(float(to['value']) * self.units, 0))
+            t.add_output(value=value, lock_script=to['scriptPubKey']['hex'],
+                         spent=True if to['spentTxId'] else False, output_n=to['n'])
+        return t
+
+    def getbalance(self, addresslist):
+        balance = 0
+        addresslist = self._addresslist_convert(addresslist)
+        for a in addresslist:
+            res = self.compose_request('addr', a.address, 'balance')
+            balance += res
+        return balance
+
+    def getutxos(self, address, after_txid='', max_txs=MAX_TRANSACTIONS):
+        address = self._address_convert(address)
+        res = self.compose_request('addrs', address.address, 'utxo')
+        txs = []
+        for tx in res:
+            if tx['txid'] == after_txid:
+                break
+            txs.append({
+                'address': address.address_orig,
+                'tx_hash': tx['txid'],
+                'confirmations': tx['confirmations'],
+                'output_n': tx['vout'],
+                'input_n': 0,
+                'block_height': tx['height'],
+                'fee': None,
+                'size': 0,
+                'value': tx['satoshis'],
+                'script': tx['scriptPubKey'],
+                'date': None
+            })
+        return txs[::-1][:max_txs]
+
+    def gettransaction(self, tx_id):
+        tx = self.compose_request('tx', tx_id)
+        return self._convert_to_transaction(tx)
+
+    def gettransactions(self, address, after_txid='', max_txs=MAX_TRANSACTIONS):
+        address = self._address_convert(address)
+        res = self.compose_request('addrs', address.address, 'txs')
+        txs = []
+        txs_dict = res['items'][::-1]
+        if after_txid:
+            txs_dict = txs_dict[[t['txid'] for t in txs_dict].index(after_txid) + 1:]
+        for tx in txs_dict[:max_txs]:
+            if tx['txid'] == after_txid:
+                break
+            txs.append(self._convert_to_transaction(tx))
+        return txs
+
+    def getrawtransaction(self, tx_id):
+        res = self.compose_request('rawtx', tx_id)
+        return res['rawtx']
+
+    def sendrawtransaction(self, rawtx):
+        res = self.compose_request('tx', 'send', variables={'rawtx': rawtx}, method='post')
+        return {
+            'txid': res['txid'],
+            'response_dict': res
+        }
+
+    # def estimatefee
+
+    def blockcount(self):
+        res = self.compose_request('status', '', variables={'q': 'getinfo'})
+        return res['info']['blocks']
+
+    def mempool(self, txid):
+        res = self.compose_request('tx', txid)
+        if res['confirmations'] == 0:
+            return res['txid']
+        return []

--- a/btcrecover/addressset.py
+++ b/btcrecover/addressset.py
@@ -35,7 +35,8 @@ def supportedChains(magic):
         b"\xfa\xbf\xb5\xda":1,    #Vertcoin
         b"\xf7\xa7\x7e\xff":0,    #Verge
         b"\xc0\xc0\xc0\xc0":0,    #dogecoin
-        b"\xfa\xc3\xb6\xda":1     #digibyte
+        b"\xfa\xc3\xb6\xda":1,    #digibyte
+        b"\xf9\xbe\xb4\xd4":1     #groestlcoin
         }
     return switcher.get(magic,-1)
         

--- a/btcrecover/test/test_seeds.py
+++ b/btcrecover/test/test_seeds.py
@@ -246,6 +246,33 @@ class TestRecoveryFromMPK(unittest.TestCase):
             "certain come keen collect slab gauge photo inside mechanic deny leader drop",
             passphrase=u"btcr-тест-пароль")
 
+    def test_groestlcoinj_xpub_legacy(self):
+            # an xpub at path m/0', as Bitcoin Wallet for Android/BlackBerry would export
+            self.mpk_tester(btcrseed.WalletBitcoinj,
+                "xpub67tjk7ug7iNivs1f1pmDswDDbk6kRCe4U1AXSiYLbtp6a2GaodSUovt3kNrDJ2q18TBX65aJZ7VqRBpnVJsaVQaBY2SANYw6kgZf4PGcxjU",
+                "laundry foil reform disagree cotton hope loud mix wheel snow real board")
+
+    def test_grs_bip39_xpub(self):
+        # an xpub at path m/44'/17'/0', as any native segwit BIP39 wallet would export
+        self.mpk_tester(btcrseed.WalletBIP39,
+            "xpub6FPF487W2VhCCKBUXuSAVtSTe8MxEJikuQTxicJxfHHAZbBQLsGHNdCYCHEbNmpzaXMvJWKQ6y93BtXSkte2oRmtvuYbm8bKcUUL5LCuQbo",
+            "certain come keen collect slab gauge photo inside mechanic deny leader drop",
+            "m/44'/17'/0'/0")
+
+    def test_grs_bip39_ypub(self):
+        # an ypub at path m/49'/17'/0', as any native segwit BIP39 wallet would export
+        self.mpk_tester(btcrseed.WalletBIP39,
+            "ypub6YwUoVLhxxKrNrvireT1onpSWXFRGvp4kHGceUqhK8Xja99tGAdmQqUSQceyGMAhK1c5mnFKMVUBokmS2Ka2C2jRTGZrm4nHzxVyDM48egV",
+            "ice stool great wine enough odor vocal crane owner magnet absent scare",
+            "m/49'/17'/0'/0")
+
+    def test_grs_bip39_zpub(self):
+        # an zpub at path m/84'/17'/0', as any native segwit BIP39 wallet would export
+        self.mpk_tester(btcrseed.WalletBIP39,
+            "zpub6u5Ro8kyXwV3zueN2G8fUwJ1hHAjYN6Ld1VCK9KGMw6m2R5M8ZtqBCrp6aQXZVh9cJWGvSm4J8mBwSsYboYfR5Ybsv8LeSYYWQk5ZhHJE4a",
+            "ice stool great wine enough odor vocal crane owner magnet absent scare",
+            "m/84'/17'/0'/0")
+
 
 is_sha3_loadable = None
 def can_load_keccak():
@@ -437,6 +464,10 @@ class TestRecoveryFromAddress(unittest.TestCase):
     def test_bip44_addr_DOGE(self):
         self.address_tester(btcrseed.WalletBIP39, "DANb1e9B2WtHJNDJUsiu1fTrtAzGJhqkPa", 2,
             "element entire sniff tired miracle solve shadow scatter hello never tank side sight isolate sister uniform advice pen praise soap lizard festival connect baby", "m/44'/3'/0'/0")
+
+    def test_bip44_addr_GRS(self):
+        self.address_tester(btcrseed.WalletBIP39, "FWoJyPj8sFzBN1dVdLfG8ozrVLRjwZaC78", 2,
+            "element entire sniff tired miracle solve shadow scatter hello never tank side sight isolate sister uniform advice pen praise soap lizard festival connect baby", "m/44'/17'/0'/0")
 
     @unittest.skipUnless(can_load_keccak(), "requires pycryptodome")
     def test_ethereum_addr(self):

--- a/cashaddress/base58.py
+++ b/cashaddress/base58.py
@@ -36,6 +36,7 @@ with the bitcoin network.
 __version__ = '0.2.5'
 
 from hashlib import sha256
+import groestlcoin_hash
 
 # 58 character alphabet used
 alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
@@ -127,6 +128,25 @@ def b58decode_check(v):
     result = b58decode(v)
     result, check = result[:-4], result[-4:]
     digest = sha256(sha256(result).digest()).digest()
+
+    if check != digest[:4]:
+        raise ValueError("Invalid checksum")
+
+    return result
+
+def b58grsencode_check(v):
+    '''Encode a string using Base58 GRS with a 4 character checksum'''
+
+    digest = groestlcoin_hash.getHash(v, len(v))
+    return b58encode(v + digest[:4])
+
+
+def b58grsdecode_check(v):
+    '''Decode and verify the checksum of a Base58 GRS encoded string'''
+
+    result = b58decode(v)
+    result, check = result[:-4], result[-4:]
+    digest = groestlcoin_hash.getHash(result, len(result))
 
     if check != digest[:4]:
         raise ValueError("Invalid checksum")

--- a/docs/Seedrecover_Quick_Start_Guide.md
+++ b/docs/Seedrecover_Quick_Start_Guide.md
@@ -12,6 +12,7 @@
     * Vertcoin
     * Monacoin
     * DigiByte
+    * Groestlcoin
     * And many other 'Bitcoin Like' cryptos
  * Seed/Passphrase recovery via Address DB (Where you don't need to know an address to search for) supporting:
     * Bitcoin
@@ -20,6 +21,7 @@
     * Vertcoin
     * Monacoin
     * DigiByte
+    * Groestlcoin
     * Likely many other 'Bitcoin like' cryptos
     
 See extra notes for [Descrambling 12 word seeds](BIP39_descrambling_seedlists.md) (Using Tokenlist feature for BIP39 seeds via seedrecover.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ coincurve==13.0.0
 green==3.1.1
 protobuf==3.11.3
 pycryptodome==3.9.7
-groestlcoin_hash==1.0.1
+groestlcoin_hash==1.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ coincurve==13.0.0
 green==3.1.1
 protobuf==3.11.3
 pycryptodome==3.9.7
+groestlcoin_hash==1.0.1


### PR DESCRIPTION
Groestlcoin is a coin similar to Bitcoin in that it supports Segwit, but it differs in that the hash function used for address checksum  is a double groestl instead of double SHA256. The groestl hash is one of the SHA-3 candidates and is the 512bit version that is truncated to 256 bits at the end of the function.

To handle this hash function, we have to import groestlcoin_hash and handle some exceptions differently.

Tests were added to prove that handling Groestlcoin addresses work and no other test fails.

Services were added for groestlcoind and other block explorers.  Some code such as Groestlsight and GroestlcoinEsplora may be duplicated and unnecessary as these are unchanged from InsightDash and Blockstream - these service were not tested.

Let me know if anything else needs to be changed or added.