### PR TITLE
Fix TypeError: 'filter' object is not subscriptable when using --gpu-names

### DIFF
--- a/btcrecover/btcrpass.py
+++ b/btcrecover/btcrpass.py
@@ -3505,7 +3505,7 @@ def parse_arguments(effective_argv, wallet = None, base_iterator = None,
     if args.enable_gpu:
         if not hasattr(loaded_wallet, "init_opencl_kernel"):
             error_exit(loaded_wallet.__class__.__name__ + " does not support GPU acceleration")
-        devices_avail = get_opencl_devices()  # all available OpenCL device objects
+        devices_avail = list(get_opencl_devices())  # all available OpenCL device objects
         if not devices_avail:
             error_exit("no supported GPUs found")
         if args.int_rate <= 0:


### PR DESCRIPTION
I was getting this with Win10 Python39

```
python3 btcrecover.py --wallet ./btcrecover/test/test-wallets/bitcoincore-wallet.dat --performance --enable-gpu --global-ws 4096 --local-ws 256 --gpu-names Ellesmere
```

```
Traceback (most recent call last):
  File "E:\btcrecover-master\btcrecover.py", line 38, in <module>
    btcrpass.parse_arguments(sys.argv[1:])
  File "E:\btcrecover-master\btcrecover\btcrpass.py", line 3530, in parse_arguments
    devices.append(devices_avail[i])
TypeError: 'filter' object is not subscriptable
```