### PR TITLE
changed behave of log output in case of false positive

### DIFF
--- a/btcrecover/btcrpass.py
+++ b/btcrecover/btcrpass.py
@@ -1781,14 +1781,15 @@ class WalletBlockchain(object):
                             return True # Only return true if we can successfully decode the block in to ascii
 
                     except UnicodeDecodeError: # Likely a false positive if we can't...
+                    # false positives seem most likely to include the word 'guid' but does not follow any further pattern
                         with open('possible_passwords.log', 'a') as logfile:
                             logfile.write(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S") +
-                                          " Found Likely False Positive Password ==>" +
+                                          " Found Likely False Positive Password (with non-Ascii characters in decrypted block) ==>" +
                                           password.decode("utf_8") +
                                           "<== in Decrypted Block ==>" +
                                           unencrypted_block.decode("utf-8", "ignore") +
-                                          "<==\n" +
-                                          "(Non-Ascii characters in decrypted block)")
+                                          "<==\n")
+                            
 
         return False
 


### PR DESCRIPTION
Only changed the log output.
Right now, the software is continueing the log output in the same line as (Non-Ascii characters in decrypted block)

`(Non-Ascii characters in decrypted block)2021-03-07 19:28:03 Possible Password ==>`