### PR TITLE
Use `\r\n` line endings on `seedrecover.py`

### DIFF
--- a/seedrecover.py
+++ b/seedrecover.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # seedrecover.py -- Bitcoin mnemonic sentence recovery tool
 # Copyright (C) 2014-2017 Christopher Gurnee


### PR DESCRIPTION
Closes #194.

Also uses `python3` as the binary name for no chance of mixup in Python versions supported.