### PR TITLE
Add RSK derivation path (commented by default)

### DIFF
--- a/derivationpath-lists/ETH.txt
+++ b/derivationpath-lists/ETH.txt
@@ -11,6 +11,7 @@ m/44'/60'/0'/0 #Ethereum MEW, Trezor, etc (Binance Smart Chain uses this path to
 # Other Eth clones that can be used with the Eth wallet type
 #m/44'/61'/0'/0 #ETC
 #m/44'/60'/160720'/0' #ETC Coinomi & Ledger Legacy
+#m/44'/137'/0'/0 #RSK
 #m/44'/178'/0'/0 #POA 
 #m/44'/242'/0'/0 #NIM (Nimiq)
 #m/44'/425'/0'/0 #AION


### PR DESCRIPTION
Manually tested by uncommenting the new line with RSK derivation path and confirming the recovery of a seed phrase from an address.

I didn't include a test because I didn't want to enable the new derivation path by default in ETH.txt﻿. If a test is mandatory, please point out the right way to do so.
