### PR TITLE
Fix spelling in Bech32 segwit address tests

### DIFF
--- a/lib/bitcoinlib_mod/tests/test_encoding.py
+++ b/lib/bitcoinlib_mod/tests/test_encoding.py
@@ -296,7 +296,7 @@ INVALID_ADDRESS_ENC = [
 
 class TestEncodingBech32SegwitAddresses(unittest.TestCase):
     """
-    Reference tests for bech32 segwit adresses
+    Reference tests for bech32 segwit addresses
 
     Copyright (c) 2017 Pieter Wuille
     Source: https://github.com/sipa/bech32/tree/master/ref/python


### PR DESCRIPTION
## Summary
- fix typo in `TestEncodingBech32SegwitAddresses` docstring

## Testing
- `python -m py_compile lib/bitcoinlib_mod/tests/test_encoding.py`

------
https://chatgpt.com/codex/tasks/task_e_687fa5d801b48322a57c2f67a1d13660