### PR TITLE
Fix bytes_to_int compatibility

### DIFF
--- a/btcrecover/addressset.py
+++ b/btcrecover/addressset.py
@@ -54,7 +54,7 @@ def bytes_to_int(bytes_rep):
     bytes_len = len(bytes_rep)
     if bytes_len <= 4:
         return struct.unpack(">I", (4-bytes_len)*b"\0" + bytes_rep)[0]
-    return long(base64.b16encode(bytes_rep), 16)
+    return int(base64.b16encode(bytes_rep), 16)
 
 
 class AddressSet(object):


### PR DESCRIPTION
## Summary
- fix addressset bytes_to_int to use `int()` instead of undefined `long`

## Testing
- `python run-all-tests.py --no-pause --no-buffer`

------
https://chatgpt.com/codex/tasks/task_e_687fa5f05768832289999ee9cb21d7bc