### PR TITLE
Add bytes_to_int_large test and fix NameError

### DIFF
--- a/btcrecover/addressset.py
+++ b/btcrecover/addressset.py
@@ -54,7 +54,7 @@ def bytes_to_int(bytes_rep):
     bytes_len = len(bytes_rep)
     if bytes_len <= 4:
         return struct.unpack(">I", (4-bytes_len)*b"\0" + bytes_rep)[0]
-    return long(base64.b16encode(bytes_rep), 16)
+    return int(base64.b16encode(bytes_rep), 16)
 
 
 class AddressSet(object):

--- a/btcrecover/test/test_seeds.py
+++ b/btcrecover/test/test_seeds.py
@@ -26,6 +26,7 @@ import warnings, unittest, os, tempfile, shutil, filecmp, sys, hashlib, random, 
 if __name__ == '__main__':
     sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 from btcrecover import btcrseed, btcrpass
+import btcrecover.addressset as addressset
 from btcrecover.addressset import AddressSet
 import btcrecover.opencl_helpers
 
@@ -1445,6 +1446,10 @@ class TestAddressSet(unittest.TestCase):
     HASH_BYTES = 1
     TABLE_LEN = 2 ** (8 * HASH_BYTES)
     BYTES_PER_ADDR = AddressSet(1)._bytes_per_addr
+
+    def test_bytes_to_int_large(self):
+        data = b'\x01\x02\x03\x04\x05'
+        self.assertEqual(addressset.bytes_to_int(data), int.from_bytes(data, 'big'))
 
     def test_add(self):
         aset = AddressSet(self.TABLE_LEN)


### PR DESCRIPTION
## Summary
- test AddressSet.bytes_to_int for multi-byte values
- fix NameError in `bytes_to_int`

## Testing
- `pytest btcrecover/test/test_seeds.py::TestAddressSet::test_bytes_to_int_large -q`
- `python run-all-tests.py --no-pause --no-buffer`

------
https://chatgpt.com/codex/tasks/task_e_687fa5fe64088322a8d9eb4a6772d04b