### PR TITLE
Tighten PBKDF2 kernel debug handling

### DIFF
--- a/lib/opencl_brute/worker/generic/pbkdf2_sha1_32.cl
+++ b/lib/opencl_brute/worker/generic/pbkdf2_sha1_32.cl
@@ -10,7 +10,7 @@
     Originally adapted from Bjorn Kerler's sha256.cl
     MIT License
 */
-#define DEBUG 1
+#define DEBUG 0    // Set to 1 to enable debug utilities for troubleshooting
 
 // All macros left defined for usage in the program
 #define ceilDiv(n,d) (((n) + (d) - 1) / (d))

--- a/lib/opencl_brute/worker/generic/pbkdf2_sha256_32.cl
+++ b/lib/opencl_brute/worker/generic/pbkdf2_sha256_32.cl
@@ -10,7 +10,7 @@
     Originally adapted from Bjorn Kerler's sha256.cl
     MIT License
 */
-#define DEBUG 1
+#define DEBUG 0    // Set to 1 to enable debug utilities for troubleshooting
 
 // All macros left defined for usage in the program
 #define ceilDiv(n,d) (((n) + (d) - 1) / (d))


### PR DESCRIPTION
## Summary
- disable debug in PBKDF2 OpenCL kernels
- note that DEBUG can be turned on for troubleshooting

## Testing
- `python3 run-all-tests.py --no-pause --no-buffer`

------
https://chatgpt.com/codex/tasks/task_e_68800b0281408322a24f9258af0b48c5