### PR TITLE
Fix outer_iterations to avoid zero

### DIFF
--- a/btcrecover/btcrpass.py
+++ b/btcrecover/btcrpass.py
@@ -9083,8 +9083,7 @@ def main():
             CHUNKSIZE_SECONDS = 1.0 / 100.0
             measure_performance_iterations = loaded_wallet.passwords_per_seconds(0.5)
             inner_iterations = int(round(2*measure_performance_iterations * CHUNKSIZE_SECONDS)) or 1  # the "2*" is due to the 0.5 seconds above
-            outer_iterations = int(round(measure_performance_iterations / inner_iterations))
-            assert outer_iterations > 0
+            outer_iterations = max(1, int(round(measure_performance_iterations / inner_iterations)))
         #
         performance_generator = performance_base_password_generator()  # generates dummy passwords
         start = timeit.default_timer()

--- a/btcrecover/test/test_passwords.py
+++ b/btcrecover/test/test_passwords.py
@@ -146,6 +146,21 @@ class GeneratorTester(unittest.TestCase):
         self.assertIn(expected_error, cm.exception.code)
 
 
+class TestOuterIterations(unittest.TestCase):
+    def test_outer_iterations_minimum(self):
+        class DummyWallet:
+            def passwords_per_seconds(self, seconds):
+                return 0
+            def return_verified_password_or_false(self, pw_list):
+                pass
+        wallet = DummyWallet()
+        CHUNKSIZE_SECONDS = 1.0 / 100.0
+        measure_performance_iterations = wallet.passwords_per_seconds(0.5)
+        inner_iterations = int(round(2 * measure_performance_iterations * CHUNKSIZE_SECONDS)) or 1
+        outer_iterations = max(1, int(round(measure_performance_iterations / inner_iterations)))
+        self.assertEqual(outer_iterations, 1)
+
+
 class Test01Basics(GeneratorTester):
 
     def test_alternate(self):


### PR DESCRIPTION
## Summary
- ensure `outer_iterations` is never zero
- add regression test for CPU measurement loop

## Testing
- `python3 run-all-tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68892fb1dd808322af77df9cbe886a89