### PR TITLE
create-address-db.py - skip processing after endBlockDate

### DIFF
--- a/btcrecover/addressset.py
+++ b/btcrecover/addressset.py
@@ -497,6 +497,7 @@ def create_address_db(dbfilename, blockdir, table_len, startBlockDate="2019-01-0
             print("-------------------   ------------     -------------     -------------------")
             # e.g. blk00943.dat   255,212,706
 
+        exit_after_lastblockdate = False
         for filenum in itertools.count(first_filenum):
             filename = path.join(blockdir, "blk{:05}.dat".format(filenum))
             if not path.isfile(filename):
@@ -595,6 +596,11 @@ def create_address_db(dbfilename, blockdir, table_len, startBlockDate="2019-01-0
 
                     header = blockfile.read(8)  # read in the next magic and remaining block length
 
+                    if blockDate > datetime.strptime(endBlockDate + " 23:59:59", '%Y-%m-%d %H:%M:%S'):
+                        # force exit
+                        header = b"\0\0"
+                        exit_after_lastblockdate = True
+
             if progress_bar:
                 block_bar_widgets[3] = progressbar.FormatLabel(" {:11,} addrs. %(elapsed)s, ".format(len(address_set))) # updates address count
                 nextval = progress_bar.currval + 1
@@ -604,6 +610,9 @@ def create_address_db(dbfilename, blockdir, table_len, startBlockDate="2019-01-0
             else:
                 print("   {:13,}".format(len(address_set)), end="")
                 print("    ", blockDate)
+
+            if exit_after_lastblockdate:
+                break
 
         if progress_bar:
             progress_bar.widgets.pop()  # remove the ETA


### PR DESCRIPTION
create-address-db.py doesn't stop processing after reaching endBlockDate. This change skips all following blocks after endBlockDate and the addressDB gets written more early. It is especially useful if you are on tight memory conditions and have to work with slices of addressDB.