### PR TITLE
Reuse cached pbkdf2 kernels

### DIFF
--- a/lib/opencl_brute/opencl.py
+++ b/lib/opencl_brute/opencl.py
@@ -894,8 +894,10 @@ class opencl_algos:
         prg = ctx[0]
         bufStructs = ctx[1]
 
+        pbkdf2_kernel = prg.pbkdf2
+
         def func(s, pwdim, pass_g, salt_g, result_g):
-            prg.pbkdf2(
+            pbkdf2_kernel(
                 s.queue,
                 pwdim,
                 None,
@@ -947,8 +949,10 @@ class opencl_algos:
         prg = ctx[0]
         bufStructs = ctx[1]
 
+        pbkdf2_saltlist_kernel = prg.pbkdf2_saltlist
+
         def func(s, pwdim, pass_g, salt_g, result_g):
-            prg.pbkdf2_saltlist(
+            pbkdf2_saltlist_kernel(
                 s.queue,
                 pwdim,
                 None,


### PR DESCRIPTION
## Summary
- cache the pbkdf2 and pbkdf2_saltlist kernels after program compilation to avoid repeated retrieval warnings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8792424b88322bc9ab8e9c8ee9502