### PR TITLE
Enable PC speaker tones for recovery alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ To try recovering your password or a BIP39 passphrase, please start with the **[
 
 If you mostly know your recovery seed/mnemonic (12-24 recovery words), but think there may be a mistake in it, please see the **[Seed Recovery Quick Start](docs/Seedrecover_Quick_Start_Guide.md)**.
 
+## Audible Alerts ##
+
+Command-line recoveries support an optional `--beep-on-find` flag that plays a double-beep pattern every five seconds after a successful recovery and emits a single beep when the search finishes without a match. The alert still prints the ASCII bell character so terminals can raise their own notification, but *btcrecover* now also tries to engage the Linux console tone generator so the on-board PC speaker can sound even when the terminal would stay silent. The helper first attempts to open `/dev/console` (or the device named by `BTCRECOVER_CONSOLE_BELL`) for the tone ioctl; if that fails it falls back to writing the bell character directly, exactly as before. Set the environment variable to an empty string to disable the console access entirely or to another device path if your distribution exposes the speaker elsewhere.
+
 ## If this tool or other content on my YouTube channel was helpful, feel free to send a tip to: ##
 
 ![Donate Bitcoin](docs/Images/donate-btc-qr.png)

--- a/btcrecover.py
+++ b/btcrecover.py
@@ -27,7 +27,7 @@
 
 import compatibility_check
 
-from btcrecover import btcrpass
+from btcrecover import btcrpass, success_alert
 import sys, multiprocessing
 
 if __name__ == "__main__":
@@ -39,6 +39,7 @@ if __name__ == "__main__":
 	(password_found, not_found_msg) = btcrpass.main()
 
 	if isinstance(password_found, str):
+		success_alert.start_success_beep()
 		print()
 		print("If this tool helped you to recover funds, please consider donating 1% of what you recovered, in your crypto of choice to:")
 		print("BTC: 37N7B7sdHahCXTcMJgEnHz7YmiR4bEqCrS ")
@@ -61,17 +62,22 @@ if __name__ == "__main__":
 		btcrpass.safe_print("Password found: '" + password_found + "'")
 		if any(ord(c) < 32 or ord(c) > 126 for c in password_found):
 			print("HTML Encoded Password:   '" + password_found.encode("ascii", "xmlcharrefreplace").decode() + "'")
+		success_alert.wait_for_user_to_stop()
 		retval = 0
 
 	elif not_found_msg:
 		print(not_found_msg, file=sys.stderr if btcrpass.args.listpass else sys.stdout)
+		success_alert.beep_failure_once()
 		retval = 0
 
 	else:
+		success_alert.beep_failure_once()
 		retval = 1  # An error occurred or Ctrl-C was pressed
 
 	# Wait for any remaining child processes to exit cleanly (to avoid error messages from gc)
 	for process in multiprocessing.active_children():
 		process.join(1.0)
+
+	success_alert.stop_success_beep()
 
 	sys.exit(retval)

--- a/btcrecover/btcrpass.py
+++ b/btcrecover/btcrpass.py
@@ -32,6 +32,7 @@ import sys, argparse, itertools, string, re, multiprocessing, signal, os, pickle
 
 # Import modules bundled with BTCRecover
 import btcrecover.opencl_helpers
+from . import success_alert
 import lib.cardano.cardano_utils as cardano
 from lib.eth_hash.auto import keccak
 from lib.mnemonic_btc_com_tweaked import Mnemonic
@@ -6011,6 +6012,11 @@ def init_parser_common():
         parser_common.add_argument("--listpass",    action="store_true", help="just list all password combinations to test and exit")
         parser_common.add_argument("--performance", action="store_true", help="run a continuous performance test (Ctrl-C to exit)")
         parser_common.add_argument("--pause",       action="store_true", help="pause before exiting")
+        parser_common.add_argument(
+            "--beep-on-find",
+            action="store_true",
+            help="play a terminal bell every five seconds when a password is found",
+        )
         parser_common.add_argument("--possible-passwords-file", metavar="FILE", default = "possible_passwords.log", help="Specify the file to save possible close matches to. (Defaults to possible_passwords.log)")
         parser_common.add_argument("--disable-save-possible-passwords",       action="store_true", help="Disable saving possible matches to file")
         parser_common.add_argument("--version","-v",action="store_true", help="show full version information and exit")
@@ -6202,6 +6208,7 @@ def parse_arguments(effective_argv, wallet = None, base_iterator = None,
         pass
     #
     args = parser.parse_args(effective_argv)
+    success_alert.set_beep_on_find(args.beep_on_find)
 
     # Do this as early as possible so user doesn't miss any error messages
     if args.pause: enable_pause()
@@ -6252,6 +6259,7 @@ def parse_arguments(effective_argv, wallet = None, base_iterator = None,
         # Add these in as non-options so that args gets a copy of their values
         parser.set_defaults(autosave=False, restore=False)
         args = parser.parse_args(effective_argv)
+        success_alert.set_beep_on_find(args.beep_on_find)
 
     # Manually handle the --help option, now that we know which help (tokenlist, not passwordlist) to print
     elif args.help:
@@ -6300,6 +6308,7 @@ def parse_arguments(effective_argv, wallet = None, base_iterator = None,
             tokenlist_args = first_line.split()          # TODO: support quoting / escaping?
             effective_argv = tokenlist_args + effective_argv  # prepend them so that real argv takes precedence
             args = parser.parse_args(effective_argv)     # reparse the arguments
+            success_alert.set_beep_on_find(args.beep_on_find)
             # Check this again as early as possible so user doesn't miss any error messages
             if args.pause: enable_pause()
             for arg in tokenlist_args:
@@ -6331,6 +6340,7 @@ def parse_arguments(effective_argv, wallet = None, base_iterator = None,
         print("Last session ended having finished password #", savestate["skip"])
         restore_filename = args.restore      # save this before it's overwritten below
         args = parser.parse_args(effective_argv)
+        success_alert.set_beep_on_find(args.beep_on_find)
         # Check this again as early as possible so user doesn't miss any error messages
         if args.pause: enable_pause()
         # If the order of passwords generated has changed since the last version, don't permit a restore

--- a/btcrecover/btcrseed.py
+++ b/btcrecover/btcrseed.py
@@ -31,6 +31,7 @@ from typing import AnyStr, List, Optional, Sequence, TypeVar, Union
 
 # Import modules bundled with BTCRecover
 from . import btcrpass
+from . import success_alert
 from .addressset import AddressSet
 from lib.bitcoinlib import encoding
 from lib.cashaddress import convert, base58
@@ -3834,6 +3835,11 @@ def main(argv):
         parser.add_argument("--no-progress", action="store_true",   help="disable the progress bar")
         parser.add_argument("--no-pause",    action="store_true",   help="never pause before exiting (default: auto)")
         parser.add_argument("--no-gui", action="store_true", help="Force disable the gui elements")
+        parser.add_argument(
+            "--beep-on-find",
+            action="store_true",
+            help="play a terminal bell every five seconds when a seed is found",
+        )
         parser.add_argument("--performance", action="store_true",   help="run a continuous performance test (Ctrl-C to exit)")
         parser.add_argument("--btcr-args",   action="store_true",   help=argparse.SUPPRESS)
         parser.add_argument("--version","-v",action="store_true",   help="show full version information and exit")
@@ -3891,6 +3897,8 @@ def main(argv):
             disable_security_warnings = True
         else:
             disable_security_warnings = False
+
+        success_alert.set_beep_on_find(args.beep_on_find)
 
         # Version information is always printed by seedrecover.py, so just exit
         if args.version: sys.exit(0)

--- a/btcrecover/success_alert.py
+++ b/btcrecover/success_alert.py
@@ -1,0 +1,237 @@
+"""Helpers for emitting an audible alert when recovery succeeds."""
+
+from __future__ import annotations
+
+import atexit
+import os
+import sys
+import threading
+import time
+from typing import Iterable, Optional, TextIO
+
+try:
+    import fcntl  # type: ignore
+except ImportError:  # pragma: no cover - not expected on Windows
+    fcntl = None  # type: ignore
+
+_KDMKTONE = 0x4B30
+_PC_SPEAKER_FREQUENCY_HZ = 880
+_PC_SPEAKER_DURATION_MS = 150
+
+_beep_enabled = False
+_success_beep_stop_event: Optional[threading.Event] = None
+_success_beep_thread: Optional[threading.Thread] = None
+_console_bell_stream: Optional[TextIO] = None
+_console_open_attempted = False
+_pcspeaker_available: Optional[bool] = None
+_write_lock = threading.Lock()
+
+
+def _console_bell_fd() -> Optional[int]:
+    stream = _ensure_console_bell_stream()
+    if stream is None:
+        return None
+
+    try:
+        return stream.fileno()
+    except Exception:
+        return None
+
+
+def _emit_pc_speaker_beep(duration_ms: int, frequency_hz: int) -> bool:
+    """Attempt to ring the internal PC speaker directly."""
+
+    global _pcspeaker_available
+
+    if _pcspeaker_available is False:
+        return False
+
+    if fcntl is None:
+        _pcspeaker_available = False
+        return False
+
+    fd = _console_bell_fd()
+    if fd is None:
+        _pcspeaker_available = False
+        return False
+
+    if duration_ms <= 0 or frequency_hz <= 0:
+        return False
+
+    try:
+        fcntl.ioctl(fd, _KDMKTONE, (frequency_hz << 16) | duration_ms)
+    except OSError:
+        _pcspeaker_available = False
+        return False
+
+    _pcspeaker_available = True
+    return True
+
+
+def _close_console_bell_stream() -> None:
+    global _console_bell_stream
+
+    stream = _console_bell_stream
+    _console_bell_stream = None
+    if stream is not None:
+        try:
+            stream.close()
+        except Exception:
+            pass
+
+
+def _ensure_console_bell_stream() -> Optional[TextIO]:
+    """Return a handle that writes directly to the system console when possible."""
+
+    global _console_bell_stream, _console_open_attempted
+
+    if _console_bell_stream is not None or _console_open_attempted:
+        return _console_bell_stream
+
+    _console_open_attempted = True
+
+    console_path = os.environ.get("BTCRECOVER_CONSOLE_BELL", "/dev/console")
+    if not console_path:
+        return None
+
+    try:
+        stream = open(console_path, "w", encoding="utf-8", errors="ignore")
+    except OSError:
+        return None
+
+    _console_bell_stream = stream
+    atexit.register(_close_console_bell_stream)
+    return _console_bell_stream
+
+
+def _bell_streams(skip_console: bool = False) -> Iterable[TextIO]:
+    """Yield file-like objects that should receive BEL characters."""
+
+    for name in ("stdout", "stderr"):
+        stream = getattr(sys, name, None)
+        if stream is None:
+            continue
+        try:
+            if stream.isatty():
+                yield stream
+        except Exception:
+            continue
+
+    if not skip_console:
+        console_stream = _ensure_console_bell_stream()
+        if console_stream is not None:
+            yield console_stream
+
+
+def _emit_beeps(count: int, spacing: float = 0.2) -> None:
+    """Emit ``count`` terminal bell characters with ``spacing`` seconds between them."""
+
+    for index in range(count):
+        with _write_lock:
+            pcspeaker = _emit_pc_speaker_beep(
+                _PC_SPEAKER_DURATION_MS,
+                _PC_SPEAKER_FREQUENCY_HZ,
+            )
+            emitted = False
+            for stream in _bell_streams(skip_console=pcspeaker):
+                try:
+                    stream.write("\a")
+                    stream.flush()
+                    emitted = True
+                except Exception:
+                    continue
+
+            if not emitted and not pcspeaker:
+                # Fall back to the default stdout behaviour even if it is not a TTY.
+                try:
+                    sys.stdout.write("\a")
+                    sys.stdout.flush()
+                except Exception:
+                    pass
+
+        if index + 1 < count:
+            time.sleep(spacing)
+
+
+def set_beep_on_find(enabled: bool) -> None:
+    """Enable or disable the background success beep."""
+
+    global _beep_enabled
+    _beep_enabled = bool(enabled)
+    if not _beep_enabled:
+        stop_success_beep()
+
+
+def start_success_beep() -> None:
+    """Begin a background thread that emits a terminal bell every five seconds."""
+
+    global _success_beep_stop_event, _success_beep_thread
+
+    if not _beep_enabled or _success_beep_thread is not None:
+        return
+
+    _success_beep_stop_event = threading.Event()
+
+    def _beep_loop() -> None:
+        while True:
+            _emit_beeps(2)
+            if _success_beep_stop_event.wait(5):
+                break
+
+    _success_beep_thread = threading.Thread(
+        target=_beep_loop,
+        name="success_beep",
+        daemon=True,
+    )
+    _success_beep_thread.start()
+
+
+def stop_success_beep() -> None:
+    """Stop the background success beep thread if it is running."""
+
+    global _success_beep_stop_event, _success_beep_thread
+
+    if _success_beep_stop_event is not None:
+        _success_beep_stop_event.set()
+    if _success_beep_thread is not None:
+        _success_beep_thread.join(timeout=0.1)
+
+    _success_beep_stop_event = None
+    _success_beep_thread = None
+
+
+def wait_for_user_to_stop(prompt: str = "\nPress Enter to stop the success alert and exit...") -> None:
+    """Wait for the user to press Enter before stopping the alert.
+
+    The wait only occurs when the success beep is active and stdin is interactive.
+    """
+
+    if not _beep_enabled or _success_beep_thread is None:
+        return
+
+    stdin = getattr(sys, "stdin", None)
+    if stdin is None:
+        return
+
+    try:
+        is_interactive = stdin.isatty()
+    except AttributeError:
+        is_interactive = False
+
+    if not is_interactive:
+        return
+
+    try:
+        input(prompt)
+    except EOFError:
+        # Non-interactive consumers may close stdin unexpectedly; just stop beeping.
+        pass
+
+
+def beep_failure_once() -> None:
+    """Emit a single terminal bell when a recovery attempt fails."""
+
+    if not _beep_enabled:
+        return
+
+    _emit_beeps(1)

--- a/seedrecover_batch.py
+++ b/seedrecover_batch.py
@@ -30,6 +30,7 @@ import os
 import compatibility_check, copy
 
 from btcrecover import btcrseed
+from btcrecover import success_alert
 import sys, multiprocessing
 
 
@@ -185,6 +186,7 @@ if __name__ == "__main__":
 
     seed_index = 0
     retval = 0
+    match_found = False
 
     for mnemonic in batch_seed_list:
         # Make a copy of the arguments
@@ -221,6 +223,8 @@ if __name__ == "__main__":
             continue
 
         if mnemonic_sentence:
+            success_alert.start_success_beep()
+            match_found = True
             _append_progress(progress_filename, seed_to_try, "MATCHED")
             if skip_completed:
                 completed_seeds.add(seed_to_try)
@@ -262,6 +266,9 @@ if __name__ == "__main__":
             if any(ord(c) > 126 for c in mnemonic_sentence):
                 print("HTML Encoded Seed:", mnemonic_sentence.encode("ascii", "xmlcharrefreplace").decode())
 
+            if not btcrseed.tk_root:
+                success_alert.wait_for_user_to_stop()
+
             if btcrseed.tk_root:      # if the GUI is being used
                 btcrseed.show_mnemonic_gui(mnemonic_sentence, path_coin)
 
@@ -285,5 +292,10 @@ if __name__ == "__main__":
     # Wait for any remaining child processes to exit cleanly (to avoid error messages from gc)
     for process in multiprocessing.active_children():
         process.join(1.0)
+
+    if not match_found:
+        success_alert.beep_failure_once()
+
+    success_alert.stop_success_beep()
 
     sys.exit(retval)


### PR DESCRIPTION
## Summary
- update the shared success alert helper to play a double-beep cadence, expose a single-beep failure helper, and now attempt to drive the PC speaker via the console tone ioctl when available
- trigger the single failure beep when password or seed recoveries end without a match while keeping the double-beep loop on success
- ensure the batch seed workflow records whether a match was found before emitting the appropriate alert
- document how the alert interacts with PC speakers and how to override or disable the console device that backs the notification

## Testing
- python -m compileall btcrecover.py seedrecover.py seedrecover_batch.py btcrecover/btcrseed.py btcrecover/btcrpass.py btcrecover/success_alert.py

------
https://chatgpt.com/codex/tasks/task_e_68d87efeb0bc832298271882901cfccd