### PR TITLE
Update CI to Python 3.14 rc3

### DIFF
--- a/.github/workflows/Latest-Run-All-Tests_Base.yml
+++ b/.github/workflows/Latest-Run-All-Tests_Base.yml
@@ -11,12 +11,12 @@ jobs:
   build:
     timeout-minutes: 20 # allow extra time for occasional slow tests
     runs-on: ${{matrix.os}}
-    continue-on-error: ${{ matrix.python-version == '3.9' || matrix.python-version == '3.14.0-rc.1' }}
+    continue-on-error: ${{ matrix.python-version == '3.9' || matrix.python-version == '3.14.0-rc.3' }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04] # Test Ubuntu Only
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14.0-rc.1'] # Test all suppoorted versions of Python
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14.0-rc.3'] # Test all suppoorted versions of Python
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/Latest-Run-All-Tests_Full.yml
+++ b/.github/workflows/Latest-Run-All-Tests_Full.yml
@@ -14,12 +14,12 @@ jobs:
   build:
     timeout-minutes: 20 # allow extra time for occasional slow tests
     runs-on: ${{matrix.os}}
-    continue-on-error: ${{ matrix.python-version == '3.9' || matrix.python-version == '3.14.0-rc.1' }}
+    continue-on-error: ${{ matrix.python-version == '3.9' || matrix.python-version == '3.14.0-rc.3' }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04] # Test Ubuntu Only
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14.0-rc.1'] # Test all suppoorted versions of Python
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14.0-rc.3'] # Test all suppoorted versions of Python
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/Weekly-Run-All-Tests-Full.yml
+++ b/.github/workflows/Weekly-Run-All-Tests-Full.yml
@@ -17,12 +17,12 @@ jobs:
   build:
     timeout-minutes: 20 # allow extra time for occasional slow tests
     runs-on: ${{matrix.os}}
-    continue-on-error: ${{ matrix.python-version == '3.9' || matrix.python-version == '3.14.0-rc.1' }}
+    continue-on-error: ${{ matrix.python-version == '3.9' || matrix.python-version == '3.14.0-rc.3' }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14.0-rc.1'] # Test all supported versions of Python
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14.0-rc.3'] # Test all supported versions of Python
         exclude:
           - os: windows-latest
             python-version: '3.13'

--- a/.github/workflows/Weekly-Run-All-Tests_Base.yml
+++ b/.github/workflows/Weekly-Run-All-Tests_Base.yml
@@ -14,12 +14,12 @@ jobs:
   build:
     timeout-minutes: 20 # allow extra time for occasional slow tests
     runs-on: ${{matrix.os}}
-    continue-on-error: ${{ matrix.python-version == '3.9' || matrix.python-version == '3.14.0-rc.1' }}
+    continue-on-error: ${{ matrix.python-version == '3.9' || matrix.python-version == '3.14.0-rc.3' }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, windows-latest, macos-latest] # Test all supported operating systems
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14.0-rc.1'] # Test all supported versions of Python
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14.0-rc.3'] # Test all supported versions of Python
         exclude:
           - os: windows-latest
             python-version: '3.13'


### PR DESCRIPTION
## Summary
- update all CI workflows to use Python 3.14.0-rc.3
- keep continue-on-error rules aligned with the new Python pre-release

## Testing
- python run-all-tests.py

------
https://chatgpt.com/codex/tasks/task_e_68e13b9962448322b0fa7521621ff505