### PR TITLE
Fix BIP39 checksum verification for long mnemonics

### DIFF
--- a/btcrecover/btcrseed.py
+++ b/btcrecover/btcrseed.py
@@ -2106,8 +2106,9 @@ class WalletBIP39(WalletBIP32):
         cksum_int = int(bit_string[-cksum_len_in_bits:], 2)
         #
         # Calculate and verify the checksum
-        return ord(hashlib.sha256(entropy_bytes).digest()[:1]) >> 8-cksum_len_in_bits \
-               == cksum_int
+        digest = hashlib.sha256(entropy_bytes).digest()
+        checksum = int.from_bytes(digest, "big") >> (len(digest) * 8 - cksum_len_in_bits)
+        return checksum == cksum_int
 
     # Called by WalletBIP32.return_verified_password_or_false() to create a binary seed
     def _derive_seed(self, mnemonic_words):


### PR DESCRIPTION
## Summary
- compute the BIP39 checksum from the full SHA-256 digest so long mnemonics no longer fail verification

## Testing
- python run-all-tests.py

------
https://chatgpt.com/codex/tasks/task_e_68e2cb43e3f08322adb4c3b97cfda84c