### PR TITLE
Limit pre-start benchmark runtime by default

### DIFF
--- a/btcrecover/btcrpass.py
+++ b/btcrecover/btcrpass.py
@@ -5999,6 +5999,18 @@ def init_parser_common():
         parser_common.add_argument("--dynamic-passwords-count", action="store_true", help=argparse.SUPPRESS) #help="start trying the passwords while they are being counted")
         parser_common.add_argument("--no-dupchecks", "-d", action="count", default=0, help="disable duplicate guess checking to save memory; specify up to four times for additional effect")
         parser_common.add_argument("--no-progress", action="store_true",   default=not sys.stdout.isatty(), help="disable the progress bar")
+        parser_common.add_argument(
+            "--pre-start-seconds",
+            type=float,
+            default=30.0,
+            metavar="SECONDS",
+            help="limit how long the pre-start benchmark runs for (default: %(default)s seconds); use 0 to skip it",
+        )
+        parser_common.add_argument(
+            "--skip-pre-start",
+            action="store_true",
+            help="skip the pre-start benchmark; equivalent to --pre-start-seconds 0",
+        )
         parser_common.add_argument("--android-pin", action="store_true", help="search for the spending pin instead of the backup password in a Bitcoin Wallet for Android/BlackBerry")
         parser_common.add_argument("--blockchain-secondpass", action="store_true", help="search for the second password instead of the main password in a Blockchain wallet")
         parser_common.add_argument("--blockchain-correct-mainpass", metavar="STRING", help="The main password for blockchain.com wallets, eithere entered using this argument, or prompted to enter at runtime")
@@ -9223,25 +9235,65 @@ def main():
         if args.enable_gpu:
             inner_iterations = sum(args.global_ws)
             outer_iterations = 1
+            approx_passwords = loaded_wallet.passwords_per_seconds(0.5)
         else:
             # Passwords are verified in "chunks" to reduce call overhead. One chunk includes enough passwords to
             # last for about 1/100th of a second (determined experimentally to be about the best I could do, YMMV)
             CHUNKSIZE_SECONDS = 1.0 / 100.0
             measure_performance_iterations = loaded_wallet.passwords_per_seconds(0.5)
-            inner_iterations = int(round(2*measure_performance_iterations * CHUNKSIZE_SECONDS)) or 1  # the "2*" is due to the 0.5 seconds above
+            inner_iterations = int(round(2 * measure_performance_iterations * CHUNKSIZE_SECONDS)) or 1  # the "2*" is due to the 0.5 seconds above
             outer_iterations = max(1, int(round(measure_performance_iterations / inner_iterations)))
-        #
-        performance_generator = performance_base_password_generator()  # generates dummy passwords
-        start = timeit.default_timer()
-        # Emulate calling the verification function with lists of size inner_iterations
+            approx_passwords = measure_performance_iterations
 
-        loaded_wallet.pre_start_benchmark = True
-        for o in range(outer_iterations):
-            loaded_wallet.return_verified_password_or_false(list(
-                itertools.islice(filter(custom_final_checker, performance_generator), inner_iterations)))
-        est_secs_per_password = (timeit.default_timer() - start) / (outer_iterations * inner_iterations)
-        del performance_generator
-        loaded_wallet.pre_start_benchmark = False
+        approx_passwords = max(approx_passwords, 1)
+        fallback_estimate = 0.5 / float(approx_passwords)
+
+        skip_pre_start = getattr(args, "skip_pre_start", False)
+        pre_start_limit = getattr(args, "pre_start_seconds", 30.0)
+
+        if pre_start_limit is not None:
+            if pre_start_limit < 0:
+                print("Warning: --pre-start-seconds must be >= 0, skipping benchmark", file=sys.stderr)
+                skip_pre_start = True
+                pre_start_limit = None
+            elif pre_start_limit == 0:
+                skip_pre_start = True
+                pre_start_limit = None
+
+        if skip_pre_start:
+            print("Skipping pre-start benchmark; progress estimates may be less accurate.")
+            est_secs_per_password = fallback_estimate
+        else:
+            message = "Pre-start benchmark: measuring verification speed"
+            if pre_start_limit is not None:
+                message += " (limit {:.3g} seconds)".format(pre_start_limit)
+            message += ". Use --skip-pre-start to skip or --pre-start-seconds to limit this step."
+            print(message)
+
+            performance_generator = performance_base_password_generator()  # generates dummy passwords
+            start = timeit.default_timer()
+            iterations_done = 0
+
+            loaded_wallet.pre_start_benchmark = True
+            try:
+                for o in range(outer_iterations):
+                    loaded_wallet.return_verified_password_or_false(list(
+                        itertools.islice(filter(custom_final_checker, performance_generator), inner_iterations)))
+                    iterations_done += inner_iterations
+                    if pre_start_limit is not None and timeit.default_timer() - start >= pre_start_limit:
+                        break
+            finally:
+                loaded_wallet.pre_start_benchmark = False
+                del performance_generator
+
+            elapsed = timeit.default_timer() - start
+            if iterations_done <= 0 or elapsed <= 0:
+                est_secs_per_password = fallback_estimate
+            else:
+                est_secs_per_password = elapsed / iterations_done
+                rate = iterations_done / elapsed
+                print("Pre-start benchmark completed in {:.2f}s ({:.2f} passwords/s).".format(elapsed, rate))
+
         assert isinstance(est_secs_per_password, float) and est_secs_per_password > 0.0
 
     if args.enable_gpu:

--- a/btcrecover/btcrseed.py
+++ b/btcrecover/btcrseed.py
@@ -4402,6 +4402,18 @@ def main(argv):
         parser.add_argument("--no-eta",      action="store_true",   help="disable calculating the estimated time to completion")
         parser.add_argument("--no-dupchecks", "-d", action="count", default=0, help="disable duplicate guess checking to save memory; specify up to four times for additional effect")
         parser.add_argument("--no-progress", action="store_true",   help="disable the progress bar")
+        parser.add_argument(
+            "--pre-start-seconds",
+            type=float,
+            default=30.0,
+            metavar="SECONDS",
+            help="limit how long the pre-start benchmark runs for (default: %(default)s seconds); use 0 to skip it",
+        )
+        parser.add_argument(
+            "--skip-pre-start",
+            action="store_true",
+            help="skip the pre-start benchmark; equivalent to --pre-start-seconds 0",
+        )
         parser.add_argument("--no-pause",    action="store_true",   help="never pause before exiting (default: auto)")
         parser.add_argument("--no-gui", action="store_true", help="Force disable the gui elements")
         parser.add_argument(
@@ -4697,13 +4709,13 @@ def main(argv):
             create_from_params["checksinglexpubaddress"] = True
 
         # These arguments and their values are passed on to btcrpass.parse_arguments()
-        for argkey in "skip", "threads", "worker", "max_eta":
+        for argkey in "skip", "threads", "worker", "max_eta", "pre_start_seconds":
             if args.__dict__[argkey] is not None:
                 extra_args.extend(("--"+argkey.replace("_", "-"), str(args.__dict__[argkey])))
 
 
         # These arguments (which have no values) are passed on to btcrpass.parse_arguments()
-        for argkey in "no_eta", "no_progress":
+        for argkey in "no_eta", "no_progress", "skip_pre_start":
             if args.__dict__[argkey]:
                 extra_args.append("--"+argkey.replace("_", "-"))
 

--- a/docs/Limitations_and_Caveats.md
+++ b/docs/Limitations_and_Caveats.md
@@ -14,6 +14,8 @@ When *btcrecover* starts, it's first task is to count all the passwords it's abo
 
 Although this initial counting phase can be skipped by using the `--no-eta` option, it's not recommended. If you do use `--no-eta`, it's highly recommended that you also use `--no-dupchecks` at the same time.
 
+Before the main search begins *btcrecover* also runs a short benchmark to estimate how quickly passwords or seeds can be checked. This can take a noticeable amount of time for some wallet types, so a message is displayed while it runs. By default the benchmark stops after about 30 seconds, but if you want to shorten or skip this step you can supply `--pre-start-seconds <seconds>` to limit how long the benchmark runs (use `0` to skip it entirely) or `--skip-pre-start`. Skipping the benchmark may reduce the accuracy of the reported ETA.
+
 You may want to always use a single `--no-dupchecks` option when working with MultiBit Classic or Electrum wallets because the duplicate checking can actually decrease CPU efficiency (and always decreases memory efficiency) with these wallets in many cases.
 
 If you specify `--no-dupchecks` more than once, it will disable even more of the duplicate checking logic:


### PR DESCRIPTION
## Summary
- set the default limit for the pre-start benchmark to 30 seconds in both CLI entry points
- keep existing skip behaviour while documenting the new default for users

## Testing
- python run-all-tests.py

------
https://chatgpt.com/codex/tasks/task_e_68e2cacda910832293a2b7b68cf187b3