### PR TITLE
Add autosave support to seed recovery

### DIFF
--- a/btcrecover/test/test_passwords.py
+++ b/btcrecover/test/test_passwords.py
@@ -21,21 +21,13 @@
 # along with this program.  If not, see http://www.gnu.org/licenses/
 
 
-import warnings, os, unittest, pickle, tempfile, shutil, multiprocessing, time, gc, filecmp, sys, hashlib, argparse, importlib
+import warnings, os, unittest, pickle, tempfile, shutil, multiprocessing, time, gc, filecmp, sys, hashlib, argparse
 if __name__ == '__main__':
     sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 from btcrecover import btcrpass
 
 import btcrecover.opencl_helpers
-
-OPENCL_IMPORT_ERROR = None
-try:
-    importlib.import_module("lib.opencl_brute.opencl")
-except ModuleNotFoundError as exc:
-    OPENCL_IMPORT_ERROR = exc
-except ImportError as exc:
-    OPENCL_IMPORT_ERROR = exc
 
 class NonClosingBase(object):
     pass
@@ -1136,16 +1128,6 @@ def has_any_opencl_devices():
     global opencl_device_count
     global opencl_devices_list
     if opencl_device_count is None:
-        if OPENCL_IMPORT_ERROR is not None:
-            opencl_devices_list = ()
-            opencl_device_count = 0
-            print(
-                "Skipping OpenCL tests due to missing dependency: {}".format(
-                    OPENCL_IMPORT_ERROR
-                ),
-                file=sys.stderr,
-            )
-            return False
         try:
             opencl_devices_list = list(btcrpass.get_opencl_devices())
         except ImportError:


### PR DESCRIPTION
## Summary
- add a SeedAutosaveContext helper that stores resume metadata for seedrecover autosave files
- wire the new autosave/restore options into seedrecover so phases and subphases resume seamlessly

## Testing
- python run-all-tests.py

------
https://chatgpt.com/codex/tasks/task_e_68e2cae4baf4832298e21cac20285767