### PR TITLE
Fix Optional type hint for Python 3.9 compatibility

### DIFF
--- a/btcrecover/addressset.py
+++ b/btcrecover/addressset.py
@@ -22,6 +22,7 @@ __version__ =  "1.13.0-CryptoGuide"
 
 import binascii
 import struct, base64, io, mmap, ast, itertools, sys, gc, glob, math
+from typing import Optional
 from os import path
 
 from datetime import datetime
@@ -337,7 +338,7 @@ def varint(data, offset):
     assert False
 
 #De-XOR the bytes based on their position with a repeating 8-byte key
-def xor_at(data: bytes, key: bytes | None, offset: int) -> bytes:
+def xor_at(data: bytes, key: Optional[bytes], offset: int) -> bytes:
     if not key or not data:
         return data
     m = len(key)


### PR DESCRIPTION
## Summary
- import Optional from typing in addressset so type hints are Python 3.9 compatible
- replace the Python 3.10 style union annotation in xor_at with Optional[bytes]

## Testing
- python run-all-tests.py

------
https://chatgpt.com/codex/tasks/task_e_68e423b803b88322a566569e90e7227c