### PR TITLE
Add BIP39 prefix lookup utility script

### DIFF
--- a/utilities/bip39_prefix_lookup.py
+++ b/utilities/bip39_prefix_lookup.py
@@ -45,6 +45,11 @@ def build_parser() -> argparse.ArgumentParser:
         type=validate_prefix,
         help="Prefix to match (1-3 characters). If omitted you will be prompted.",
     )
+    parser.add_argument(
+        "--count",
+        action="store_true",
+        help="Display the number of matched words on a second line.",
+    )
     return parser
 
 
@@ -64,11 +69,9 @@ def main() -> None:
             return
 
     matches = find_matching_words(prefix, wordlist)
-    joined_matches = " ".join(matches)
+    print(" ".join(matches))
 
-    if joined_matches:
-        print(f"{len(matches)} {joined_matches}")
-    else:
+    if args.count:
         print(len(matches))
 
 


### PR DESCRIPTION
## Summary
- add a command-line utility that lists BIP39 English words starting with a user-provided prefix
- support both interactive prompting and a --prefix flag while validating 1-3 character input

## Testing
- python run-all-tests.py --no-pause

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68f28f1c03808322a5d9f5f035302e65)