### PR TITLE
Support fingerprint-based BIP39 passphrase recovery

### DIFF
--- a/btcrecover/test/test_passwords.py
+++ b/btcrecover/test/test_passwords.py
@@ -1925,6 +1925,13 @@ class Test08BIP39Passwords(unittest.TestCase):
         )
         btcrpass.args = argparse.Namespace()
 
+    @skipUnless(can_load_coincurve, "requires coincurve")
+    def test_bip39_fingerprint_only(self):
+        self.bip39_tester(
+            fingerprint="0xF9D16AAE",
+            mnemonic="certain come keen collect slab gauge photo inside mechanic deny leader drop",
+        )
+
     def cardano_tester_opencl(self, *args, **kwargs):
 
         wallet = btcrpass.WalletCardano(*args, **kwargs)

--- a/btcrecover/test/test_seeds.py
+++ b/btcrecover/test/test_seeds.py
@@ -445,6 +445,23 @@ class TestRecoveryFromMPK(unittest.TestCase):
                         "ice stool great wine enough odor vocal crane owner magnet absent scare",
                         "m/84'/0'/0'/0")
 
+    def test_bip39_fingerprint_only(self):
+        wallet = btcrseed.WalletBIP39.create_from_params(fingerprint="0xEF453251")
+        wallet.config_mnemonic(
+            "certain come keen collect slab gauge photo inside mechanic deny leader drop",
+            expected_len=12,
+        )
+        correct_mnemonic = btcrseed.mnemonic_ids_guess
+        wrong_mnemonic_iter = wallet.performance_iterator()
+        guesses = (
+            next(wrong_mnemonic_iter),
+            correct_mnemonic,
+        )
+        self.assertEqual(
+            wallet.return_verified_password_or_false(guesses),
+            (correct_mnemonic, 2),
+        )
+
     def test_bip44_firstfour(self):
         # an xpub at path m/44'/0'/0', as Mycelium for Android would export
         self.mpk_tester(btcrseed.WalletBIP39,

--- a/docs/Usage_Examples/basic_password_recoveries.md
+++ b/docs/Usage_Examples/basic_password_recoveries.md
@@ -49,6 +49,8 @@ The most common symptom of you having an error in your BIP39 passphrase is that 
 
 While BIP39 seed recovery can benefit from GPU acceleration, this is currently not the case for recovering a BIP39 passphrase.
 
+If you know the wallet's master fingerprint, you can supply it with `--fingerprint` instead of providing addresses or an xpub. This is useful when you only have access to the hardware wallet but not to any derived addresses.
+
 All of the example commands below have the address generation limit set to 10, so the address they are searching for needs to be within the first 10 addresses in the wallet.
 
 **Supported wallets**

--- a/docs/Usage_Examples/basic_seed_recoveries.md
+++ b/docs/Usage_Examples/basic_seed_recoveries.md
@@ -66,6 +66,8 @@ python seedrecover.py --wallet-type aezeed --addrs 1Hp6UXuJjzt9eSBa9LhtW97KPb44b
 
 If you no longer have an address or xpub to test against, omit `--addrs` to run in checksum-only mode. BTCRecover will still try candidate seeds that satisfy the aezeed checksum and will warn that the result must be manually verified to avoid false positives.
 
+When you only have the wallet's master fingerprint (for example, from a hardware wallet export), you can pass it with `--fingerprint DEADBEAF` to validate seeds without needing an xpub, address, or address database. The fingerprint should be provided as an 8-character hex string.
+
 ### Basic Cardano Recoveries
 For Cardano recovers, [see the notes here as well.](bip39-accounts-and-altcoins.md) You can use any Shelley-Era base or stake addresses. (Byron-Era not supported)
 


### PR DESCRIPTION
## Summary
- allow BIP39 passphrase recovery to accept a master fingerprint alongside existing xpub/address inputs and propagate it through wallet loaders
- add coverage for fingerprint-only BIP39 passphrase searches and document the new flag in the password recovery guide

## Testing
- python run-all-tests.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692db6ddc80c83228cc25898360e69ae)