### PR TITLE
Fix RepeatedKernelRetrieval warning in cl_hash_iterations

### DIFF
--- a/lib/opencl_brute/opencl.py
+++ b/lib/opencl_brute/opencl.py
@@ -1046,8 +1046,17 @@ class opencl_algos:
         prg = ctx[0]
         bufStructs = ctx[1]
 
+        # `prg.hash_iterations` creates a new kernel instance every time it is
+        # accessed, which is expensive and triggers pyopencl's
+        # RepeatedKernelRetrieval warning.  Cache the kernel on the compiled
+        # program so that subsequent calls reuse the same object.
+        hash_iterations_kernel = getattr(prg, "_hash_iterations_kernel", None)
+        if hash_iterations_kernel is None:
+            hash_iterations_kernel = cl.Kernel(prg, "hash_iterations")
+            setattr(prg, "_hash_iterations_kernel", hash_iterations_kernel)
+
         def func(s, pwdim, pass_g, salt_g, result_g):
-            prg.hash_iterations(
+            hash_iterations_kernel(
                 s.queue,
                 pwdim,
                 None,


### PR DESCRIPTION
Cache the hash_iterations OpenCL kernel on the program object using getattr/setattr, matching the existing pattern used in cl_pbkdf2 and cl_pbkdf2_saltlist. This avoids repeated expensive kernel instantiation and eliminates the pyopencl RepeatedKernelRetrieval warning on Apple Silicon (and other platforms).

Tested on Apple M series.