### PR TITLE
Fix Termux CI: update Node.js path from node20 to node24 for checkout@v7

### DIFF
--- a/.github/workflows/termux-tests.yml
+++ b/.github/workflows/termux-tests.yml
@@ -22,7 +22,7 @@ jobs:
     container:
       image: termux/termux-docker:${{ matrix.architecture }}
       volumes:
-        - /tmp/node20:/__e/node20
+        - /tmp/node24:/__e/node24
     env:
       TERMUX_MAIN_PACKAGE_FORMAT: debian
       ANDROID_ROOT: /system
@@ -43,7 +43,7 @@ jobs:
       - name: install nodejs
         run: |
           /entrypoint.sh pkg install -y nodejs-lts
-          ln -sf ${PREFIX}/bin /__e/node20/bin
+          ln -sf ${PREFIX}/bin /__e/node24/bin
       - uses: actions/checkout@v7
       - name: fix permissions
         run: chown -R 1000:1000 .
@@ -66,7 +66,7 @@ jobs:
     container:
       image: termux/termux-docker:${{ matrix.architecture }}
       volumes:
-        - /tmp/node20:/__e/node20
+        - /tmp/node24:/__e/node24
     env:
       TERMUX_MAIN_PACKAGE_FORMAT: debian
       ANDROID_ROOT: /system
@@ -88,7 +88,7 @@ jobs:
       - name: install nodejs
         run: |
           /entrypoint.sh pkg install -y nodejs-lts
-          ln -sf ${PREFIX}/bin /__e/node20/bin
+          ln -sf ${PREFIX}/bin /__e/node24/bin
       - uses: actions/checkout@v7
       - name: fix permissions
         run: chown -R 1000:1000 .


### PR DESCRIPTION
Fix Termux CI failure: \`actions/checkout@v7\` uses Node 24 runtime (\`using: node24\`), but the Termux container was providing Node at \`/__e/node20\`. Updated both jobs to mount and symlink under \`/__e/node24\` instead.

Related to #741 (checkout v7 update).