### PR TITLE
Add progress, test-wallet skipping, and filename context

### DIFF
--- a/btcrecover/btcrpass.py
+++ b/btcrecover/btcrpass.py
@@ -1260,10 +1260,10 @@ class WalletBitcoinj(object):
     def load_from_filename(cls, wallet_filename):
         with open(wallet_filename, "rb") as wallet_file:
             filedata = wallet_file.read(MAX_WALLET_FILE_SIZE)  # up to 64M, typical size is a few k
-        return cls._load_from_filedata(filedata)
+        return cls._load_from_filedata(filedata, filename=wallet_filename)
 
     @classmethod
-    def _load_from_filedata(cls, filedata):
+    def _load_from_filedata(cls, filedata, filename=None):
         try:
             from . import bitcoinj_pb2
         except ModuleNotFoundError:
@@ -1274,12 +1274,16 @@ class WalletBitcoinj(object):
         pb_wallet.ParseFromString(bytes(filedata))
 
         if pb_wallet.encryption_type == bitcoinj_pb2.Wallet.UNENCRYPTED:
-            print("\nWallet Not Encrypted, Contains the following Private Keys")
+            if filename:
+                print("\nWallet Not Encrypted (File: {})".format(filename))
+            else:
+                print("\nWallet Not Encrypted")
+            print("Contains the following Private Keys:")
             for key in pb_wallet.key:
                 from lib.cashaddress import base58
                 privkey_wif = base58.b58encode_check(bytes([0x80]) + key.secret_bytes + bytes([0x1]))
                 print(privkey_wif)
-                print()
+            print()
             raise ValueError("bitcoinj wallet is not encrypted")
         if pb_wallet.encryption_type != bitcoinj_pb2.Wallet.ENCRYPTED_SCRYPT_AES:
             raise NotImplementedError("Unsupported bitcoinj encryption type "+str(pb_wallet.encryption_type))
@@ -1299,7 +1303,10 @@ class WalletBitcoinj(object):
                     self._scrypt_p    = pb_wallet.encryption_parameters.p
                     self.pb_wallet_filedata = filedata
                     return self
-                print("Warning: ignoring encrypted key of unexpected length ("+str(encrypted_len)+")", file=sys.stderr)
+                if filename:
+                    print("Warning: {} - ignoring encrypted key of unexpected length ({})".format(filename, encrypted_len), file=sys.stderr)
+                else:
+                    print("Warning: ignoring encrypted key of unexpected length ("+str(encrypted_len)+")", file=sys.stderr)
 
         raise ValueError("No encrypted keys found in bitcoinj wallet")
 
@@ -1417,7 +1424,7 @@ class WalletCoinomi(WalletBitcoinj):
         return False
 
     @classmethod
-    def _load_from_filedata(cls, filedata):
+    def _load_from_filedata(cls, filedata, filename=None):
         try:
             from . import coinomi_pb2
         except ModuleNotFoundError:
@@ -1427,7 +1434,7 @@ class WalletCoinomi(WalletBitcoinj):
         pb_wallet = coinomi_pb2.Wallet()
         pb_wallet.ParseFromString(bytes(filedata))
         if pb_wallet.encryption_type == coinomi_pb2.Wallet.UNENCRYPTED:
-            raise ValueError("Coinomi wallet is not encrypted")
+            raise ValueError("Coinomi wallet is not encrypted" + (f" ({filename})" if filename else ""))
         if pb_wallet.encryption_type != coinomi_pb2.Wallet.ENCRYPTED_SCRYPT_AES:
             raise NotImplementedError("Unsupported Coinomi wallet encryption type "+str(pb_wallet.encryption_type))
         if not pb_wallet.HasField("encryption_parameters"):
@@ -1934,7 +1941,7 @@ class WalletElectrum2(WalletElectrum):
                             return self
 
                 else:
-                    print("Warning: found unsupported keystore type " + keystore_type, file=sys.stderr)
+                    print("Warning: {} - found unsupported keystore type {}".format(wallet_filename, keystore_type), file=sys.stderr)
 
             # Electrum 2.7+ multisig or 2fa wallet
             for i in itertools.count(1):
@@ -1945,7 +1952,7 @@ class WalletElectrum2(WalletElectrum):
                     xprv = x.get("xprv")
                     if xprv: break
                 else:
-                    print("Warning: found unsupported key type " + x_type, file=sys.stderr)
+                    print("Warning: {} - found unsupported key type {}".format(wallet_filename, x_type), file=sys.stderr)
             if xprv: break
 
             # Electrum 2.0 - 2.6.4 wallet with imported loose private keys

--- a/walletfinder.py
+++ b/walletfinder.py
@@ -124,6 +124,7 @@ def _print_progress(current, total=None, current_dir=""):
     """Print a single-line progress indicator with a spinning cursor.
 
     Updates in-place by using carriage return to overwrite the line.
+    Uses ASCII-safe characters for Windows console compatibility.
     """
     spinners = ['|', '/', '-', '\\']
     spinner_idx = current % 4
@@ -135,10 +136,12 @@ def _print_progress(current, total=None, current_dir=""):
         pct = min(int(current / total * 100), 100)
         bar_len = 20
         filled = int(bar_len * current / total)
-        bar = '█' * filled + '░' * (bar_len - filled)
-        line = f"\r[{spinner}] Scanning: {pct}% [{bar}] {current}/{total}  Dir: {truncated_dir}"
+        bar = '#' * filled + '-' * (bar_len - filled)
+        line = "\r[{}] Scanning: {}% [{}] {}/{}  Dir: {}".format(
+            spinner, pct, bar, current, total, truncated_dir)
     else:
-        line = f"\r[{spinner}] Scanning: {current} files checked  Dir: {truncated_dir}"
+        line = "\r[{}] Scanning: {} files checked  Dir: {}".format(
+            spinner, current, truncated_dir)
 
     # Pad to clear previous line content
     max_len = 120
@@ -184,11 +187,15 @@ def walk_directory(folder, max_depth, current_depth=0, skip_test_wallets=True):
 
     try:
         entries = sorted(folder.iterdir())
-    except PermissionError:
+    except (PermissionError, FileNotFoundError, OSError):
         return
 
     for entry in entries:
-        if entry.is_dir():
+        try:
+            is_dir = entry.is_dir()
+        except OSError:
+            continue
+        if is_dir:
             if entry.name.startswith('.') and entry.name != '.':
                 continue
             if entry.name in EXCLUDED_DIRS:
@@ -203,69 +210,140 @@ def walk_directory(folder, max_depth, current_depth=0, skip_test_wallets=True):
             yield str(entry)
 
 
-def scan_wallet_mode(folder, depth, debug=False, skip_test_wallets=True):
+def scan_wallet_mode(folder, depth, debug=False, skip_test_wallets=True, statusbar=True):
     """Scan directory for wallet files using btcrecover's load_wallet().
 
     Returns a list of dicts with keys: path, type, confidence, (and reason if debug).
+    
+    When statusbar is True (default), uses a two-pass approach: first counts eligible files,
+    then scans them with a progress bar. When statusbar is False, scans immediately without
+    the initial discovery pass.
     """
     results = []
     files_scanned = 0
 
-    # First pass: count total eligible files for progress bar
-    total_files = 0
-    all_files = []
-    for filepath in walk_directory(Path(folder), depth, skip_test_wallets=skip_test_wallets):
-        try:
-            if os.path.getsize(filepath) <= MAX_WALLET_FILE_SIZE:
-                all_files.append(filepath)
-                total_files += 1
-        except OSError:
-            pass
+    if statusbar:
+        # First pass: count total eligible files for progress bar (with spinner)
+        total_files = 0
+        all_files = []
+        spinners = ['|', '/', '-', '\\']
+        disc_count = 0
+        for filepath in walk_directory(Path(folder), depth, skip_test_wallets=skip_test_wallets):
+            try:
+                if os.path.getsize(filepath) <= MAX_WALLET_FILE_SIZE:
+                    all_files.append(filepath)
+                    total_files += 1
+            except OSError:
+                pass
+            # Show discovery spinner every 500 files
+            disc_count += 1
+            if disc_count % 500 == 0:
+                spinner_idx = disc_count % 4
+                sys.stdout.write("\r[{}] Discovering files... {}".format(spinners[spinner_idx], total_files))
+                sys.stdout.flush()
+        _clear_progress_line()
 
-    # Second pass: scan files with progress indicator
-    for i, filepath in enumerate(all_files):
-        files_scanned += 1
+        # Second pass: scan files with progress indicator
+        for i, filepath in enumerate(all_files):
+            files_scanned += 1
 
-        # Extract current directory being scanned (last 2-3 levels for readability)
-        try:
-            path_parts = Path(filepath).parts
-            if len(path_parts) > 3:
-                current_dir = os.sep.join(path_parts[-3:])
-            else:
+            # Extract current directory being scanned (last 2-3 levels for readability)
+            try:
+                path_parts = Path(filepath).parts
+                if len(path_parts) > 3:
+                    current_dir = os.sep.join(path_parts[-3:])
+                else:
+                    current_dir = filepath
+            except Exception:
                 current_dir = filepath
-        except Exception:
-            current_dir = filepath
 
-        _print_progress(files_scanned, total_files, current_dir)
+            _print_progress(files_scanned, total_files, current_dir)
 
-        try:
-            wallet_obj = load_wallet(filepath)
-            wtype = get_wallet_type_name(wallet_obj)
-            result = {
-                'path': filepath,
-                'type': wtype,
-                'confidence': getattr(wallet_obj, 'detection_confidence', 'definite'),
-            }
-            if debug:
-                result['reason'] = getattr(wallet_obj, 'detection_reason', None)
-            results.append(result)
-        except ValueError as e:
-            # Capture unencrypted wallets so the filepath is reported in results
-            error_msg = str(e).lower()
-            if "not encrypted" in error_msg or "unencrypted" in error_msg:
+            try:
+                wallet_obj = load_wallet(filepath)
+                wtype = get_wallet_type_name(wallet_obj)
                 result = {
                     'path': filepath,
-                    'type': 'Unencrypted',
-                    'confidence': 'definite',
-                    'reason': 'Wallet is not encrypted (contains exposed private keys)',
+                    'type': wtype,
+                    'confidence': getattr(wallet_obj, 'detection_confidence', 'definite'),
                 }
+                if debug:
+                    result['reason'] = getattr(wallet_obj, 'detection_reason', None)
                 results.append(result)
-            # All other ValueErrors are silently ignored
-        except (Exception, SystemExit):
-            pass
+            except ValueError as e:
+                # Capture unencrypted wallets so the filepath is reported in results
+                error_msg = str(e).lower()
+                if "not encrypted" in error_msg or "unencrypted" in error_msg:
+                    result = {
+                        'path': filepath,
+                        'type': 'Unencrypted',
+                        'confidence': 'definite',
+                        'reason': 'Wallet is not encrypted (contains exposed private keys)',
+                    }
+                    results.append(result)
+                # All other ValueErrors are silently ignored
+            except (Exception, SystemExit):
+                pass
 
-    # Clear the progress line and print a newline
-    _clear_progress_line()
+        # Clear the progress line and print a newline
+        _clear_progress_line()
+    else:
+        # No statusbar: scan files directly without counting first, but still show current directory
+        spinners = ['|', '/', '-', '\\']
+        for filepath in walk_directory(Path(folder), depth, skip_test_wallets=skip_test_wallets):
+            try:
+                if os.path.getsize(filepath) > MAX_WALLET_FILE_SIZE:
+                    continue
+            except OSError:
+                continue
+
+            files_scanned += 1
+
+            # Show current directory being scanned (single-line updating display)
+            try:
+                path_parts = Path(filepath).parts
+                if len(path_parts) > 3:
+                    current_dir = os.sep.join(path_parts[-3:])
+                else:
+                    current_dir = filepath
+            except Exception:
+                current_dir = filepath
+
+            truncated_dir = _truncate_path(current_dir)
+            spinner_idx = files_scanned % 4
+            line = "\r[{}] Scanning: {} files  Dir: {}".format(spinners[spinner_idx], files_scanned, truncated_dir)
+            max_len = 120
+            if len(line) < max_len:
+                line += ' ' * (max_len - len(line))
+            sys.stdout.write(line)
+            sys.stdout.flush()
+
+            try:
+                wallet_obj = load_wallet(filepath)
+                wtype = get_wallet_type_name(wallet_obj)
+                result = {
+                    'path': filepath,
+                    'type': wtype,
+                    'confidence': getattr(wallet_obj, 'detection_confidence', 'definite'),
+                }
+                if debug:
+                    result['reason'] = getattr(wallet_obj, 'detection_reason', None)
+                results.append(result)
+            except ValueError as e:
+                error_msg = str(e).lower()
+                if "not encrypted" in error_msg or "unencrypted" in error_msg:
+                    result = {
+                        'path': filepath,
+                        'type': 'Unencrypted',
+                        'confidence': 'definite',
+                        'reason': 'Wallet is not encrypted (contains exposed private keys)',
+                    }
+                    results.append(result)
+            except (Exception, SystemExit):
+                pass
+
+        # Clear the scanning line
+        _clear_progress_line()
 
     return results, files_scanned
 
@@ -903,6 +981,9 @@ def parse_arguments(args=None):
     scan_group.add_argument(
         '--no-skip-test-wallets', action='store_true', default=False,
         help="Do not automatically skip test wallet directories (e.g., btcrecover/test/test-wallets/).")
+    scan_group.add_argument(
+        '--no-statusbar', action='store_true', default=False,
+        help="Skip the file discovery phase and start scanning immediately without a progress bar.")
 
     args = parser.parse_args(args)
 
@@ -939,8 +1020,10 @@ def main():
         print()
         print_text_results(results, files_scanned, debug=args.debug)
     else:
+        statusbar = not args.no_statusbar
         results, files_scanned = scan_wallet_mode(folder, depth, debug=args.debug,
-                                                  skip_test_wallets=skip_test_wallets)
+                                                  skip_test_wallets=skip_test_wallets,
+                                                  statusbar=statusbar)
         print()
         print_wallet_results(results, files_scanned)
 

--- a/walletfinder.py
+++ b/walletfinder.py
@@ -28,6 +28,9 @@ from btcrecover.btcrpass import load_wallet, MAX_WALLET_FILE_SIZE
 
 
 EXCLUDED_DIRS = {'.git', 'node_modules', '__pycache__', '.venv', '.mypy_cache', '.pytest_cache'}
+
+# Directories automatically skipped (test wallets bundled with BTCRecover)
+AUTO_SKIP_DIRS = {'test-wallets', 'test_wallets'}
 MAX_MNEMONIC_FILE_SIZE = 16 * 1024
 
 # File extensions that textract can extract text from (without leading dot)
@@ -91,7 +94,86 @@ def get_wallet_type_name(wallet_obj):
     return type(wallet_obj).__name__
 
 
-def walk_directory(folder, max_depth, current_depth=0):
+# ---------------------------------------------------------------------------
+# Path truncation helpers
+# ---------------------------------------------------------------------------
+
+def _truncate_path_component(name, max_len=8):
+    """Truncate a single path component (directory or filename).
+
+    Shows first 4 chars + '...' + last 4 chars when longer than max_len.
+    Short names are returned unchanged.
+    """
+    if len(name) <= max_len:
+        return name
+    return name[:4] + '...' + name[-4:]
+
+
+def _truncate_path(path_str, component_max=8):
+    """Truncate each component of a path for compact display."""
+    parts = Path(path_str).parts
+    truncated = [_truncate_path_component(p, component_max) for p in parts]
+    return os.sep.join(truncated)
+
+
+# ---------------------------------------------------------------------------
+# Progress indicator
+# ---------------------------------------------------------------------------
+
+def _print_progress(current, total=None, current_dir=""):
+    """Print a single-line progress indicator with a spinning cursor.
+
+    Updates in-place by using carriage return to overwrite the line.
+    """
+    spinners = ['|', '/', '-', '\\']
+    spinner_idx = current % 4
+    spinner = spinners[spinner_idx]
+
+    truncated_dir = _truncate_path(current_dir)
+
+    if total and total > 0:
+        pct = min(int(current / total * 100), 100)
+        bar_len = 20
+        filled = int(bar_len * current / total)
+        bar = '█' * filled + '░' * (bar_len - filled)
+        line = f"\r[{spinner}] Scanning: {pct}% [{bar}] {current}/{total}  Dir: {truncated_dir}"
+    else:
+        line = f"\r[{spinner}] Scanning: {current} files checked  Dir: {truncated_dir}"
+
+    # Pad to clear previous line content
+    max_len = 120
+    if len(line) < max_len:
+        line += ' ' * (max_len - len(line))
+
+    sys.stdout.write(line)
+    sys.stdout.flush()
+
+
+def _clear_progress_line():
+    """Clear the progress indicator line."""
+    sys.stdout.write("\r" + " " * 120 + "\r")
+    sys.stdout.flush()
+
+
+# ---------------------------------------------------------------------------
+# Test-wallet directory helpers
+# ---------------------------------------------------------------------------
+
+def _is_test_wallet_dir(dir_path):
+    """Check if a directory is a test wallet directory that should be auto-skipped.
+
+    Matches directories named 'test-wallets' or 'test_wallets' anywhere in the path,
+    typically found under btcrecover/test/ within the BTCRecover installation.
+    """
+    name = dir_path.name.lower()
+    if name in AUTO_SKIP_DIRS:
+        parent = dir_path.parent
+        if parent.name.lower() == 'test':
+            return True
+    return False
+
+
+def walk_directory(folder, max_depth, current_depth=0, skip_test_wallets=True):
     """Walk directory tree with depth limiting and exclusion filtering.
 
     Yields (filepath,) for each file found.
@@ -111,14 +193,17 @@ def walk_directory(folder, max_depth, current_depth=0):
                 continue
             if entry.name in EXCLUDED_DIRS:
                 continue
+            # Auto-skip test wallet directories
+            if skip_test_wallets and _is_test_wallet_dir(entry):
+                continue
             if max_depth is not None and current_depth >= max_depth:
                 continue
-            yield from walk_directory(entry, max_depth, current_depth + 1)
+            yield from walk_directory(entry, max_depth, current_depth + 1, skip_test_wallets)
         elif entry.is_file():
             yield str(entry)
 
 
-def scan_wallet_mode(folder, depth, debug=False):
+def scan_wallet_mode(folder, depth, debug=False, skip_test_wallets=True):
     """Scan directory for wallet files using btcrecover's load_wallet().
 
     Returns a list of dicts with keys: path, type, confidence, (and reason if debug).
@@ -126,10 +211,32 @@ def scan_wallet_mode(folder, depth, debug=False):
     results = []
     files_scanned = 0
 
-    for filepath in walk_directory(Path(folder), depth):
-        if os.path.getsize(filepath) > MAX_WALLET_FILE_SIZE:
-            continue
+    # First pass: count total eligible files for progress bar
+    total_files = 0
+    all_files = []
+    for filepath in walk_directory(Path(folder), depth, skip_test_wallets=skip_test_wallets):
+        try:
+            if os.path.getsize(filepath) <= MAX_WALLET_FILE_SIZE:
+                all_files.append(filepath)
+                total_files += 1
+        except OSError:
+            pass
+
+    # Second pass: scan files with progress indicator
+    for i, filepath in enumerate(all_files):
         files_scanned += 1
+
+        # Extract current directory being scanned (last 2-3 levels for readability)
+        try:
+            path_parts = Path(filepath).parts
+            if len(path_parts) > 3:
+                current_dir = os.sep.join(path_parts[-3:])
+            else:
+                current_dir = filepath
+        except Exception:
+            current_dir = filepath
+
+        _print_progress(files_scanned, total_files, current_dir)
 
         try:
             wallet_obj = load_wallet(filepath)
@@ -142,8 +249,23 @@ def scan_wallet_mode(folder, depth, debug=False):
             if debug:
                 result['reason'] = getattr(wallet_obj, 'detection_reason', None)
             results.append(result)
+        except ValueError as e:
+            # Capture unencrypted wallets so the filepath is reported in results
+            error_msg = str(e).lower()
+            if "not encrypted" in error_msg or "unencrypted" in error_msg:
+                result = {
+                    'path': filepath,
+                    'type': 'Unencrypted',
+                    'confidence': 'definite',
+                    'reason': 'Wallet is not encrypted (contains exposed private keys)',
+                }
+                results.append(result)
+            # All other ValueErrors are silently ignored
         except (Exception, SystemExit):
             pass
+
+    # Clear the progress line and print a newline
+    _clear_progress_line()
 
     return results, files_scanned
 
@@ -777,13 +899,18 @@ def parse_arguments(args=None):
         '--min-scattered', type=int, metavar='N', default=12,
         help='Minimum unique wordlist words in a file to report (default: 12).')
 
+    scan_group = parser.add_argument_group('scan options')
+    scan_group.add_argument(
+        '--no-skip-test-wallets', action='store_true', default=False,
+        help="Do not automatically skip test wallet directories (e.g., btcrecover/test/test-wallets/).")
+
     args = parser.parse_args(args)
-    
+
     # Set wallet_mode based on whether text mode was explicitly requested
     text_requested = args.text_mode or getattr(args, 'mnemonic_mode_compat', False)
     if not text_requested:
         args.wallet_mode = True
-    
+
     return args
 
 
@@ -804,6 +931,7 @@ def main():
 
     # Determine which mode to use (text-mode is default, mnemonic-mode is backward compat alias)
     text_mode = args.text_mode or getattr(args, 'mnemonic_mode_compat', False)
+    skip_test_wallets = not args.no_skip_test_wallets
 
     if text_mode:
         results, files_scanned = scan_text_mode(
@@ -811,7 +939,8 @@ def main():
         print()
         print_text_results(results, files_scanned, debug=args.debug)
     else:
-        results, files_scanned = scan_wallet_mode(folder, depth, debug=args.debug)
+        results, files_scanned = scan_wallet_mode(folder, depth, debug=args.debug,
+                                                  skip_test_wallets=skip_test_wallets)
         print()
         print_wallet_results(results, files_scanned)
 


### PR DESCRIPTION
Improve wallet scanning UX and error context across the project.

- btcrecover/btcrpass.py: propagate an optional filename into _load_from_filedata and include the filename in printed messages and warnings for bitcoinj and Coinomi wallets (unencrypted warnings and unexpected encrypted key lengths). Adjusted method signatures to accept filename=None.
- walletfinder.py: add automatic skipping for bundled test-wallet directories, path truncation helpers, and a single-line progress indicator (spinner + progress bar). walk_directory now supports skipping test-wallets; scan_wallet_mode does a two-pass file count to drive the progress UI, captures unencrypted-wallet ValueErrors into results, and clears the progress line on completion. Added CLI flag --no-skip-test-wallets to override automatic skipping.

These changes improve usability when scanning large trees and make diagnostic output more actionable by showing file context. Function signature changes are backwards-compatible (filename is optional).